### PR TITLE
Fix json error handling for PHP <5.3.3

### DIFF
--- a/code/Helper/algoliasearch.php
+++ b/code/Helper/algoliasearch.php
@@ -667,7 +667,7 @@ function AlgoliaUtils_requestHost($curlHandle, $method, $host, $path, $params, $
         case JSON_ERROR_STATE_MISMATCH:
             $errorMsg = 'JSON parsing error: underflow or the modes mismatch';
             break;
-        case JSON_ERROR_UTF8:
+        case (defined(JSON_ERROR_UTF8) ? JSON_ERROR_UTF8 : -1): // PHP 5.3 less than 5.3.3 (Ubuntu 10.04 LTS)
             $errorMsg = 'JSON parsing error: malformed UTF-8 characters, possibly incorrectly encoded';
             break;
         case JSON_ERROR_NONE:


### PR DESCRIPTION
Ubuntu 10.04 LTS is still supported by Canonical until April 2015 and uses a PHP version based on 5.3.2 with security fixes.
