### PR TITLE
Minor improvements

### DIFF
--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -52,6 +52,13 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
      */
     static private $_predefinedSpecialAttributes = array('_tags');
 
+    /**
+     * Data prefix to retrieve Algolia search specific data for the entity.
+     *
+     * @var string
+     */
+    private $_dataPrefix = 'algolia_';
+
     public function getTopSearchTemplate()
     {
         return 'algoliasearch/topsearch.phtml';
@@ -258,7 +265,10 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
             $data['image_url'] = $imageUrl;
         }
         foreach ($this->getCategoryAdditionalAttributes($storeId) as $attributeCode) {
-            $value = Mage::getResourceSingleton('algoliasearch/fulltext')->getAttributeValue($attributeCode, $category->getData($attributeCode), $storeId, Mage_Catalog_Model_Category::ENTITY);
+            $value = $category->hasData($this->_dataPrefix.$attributeCode)
+                ? $category->getData($this->_dataPrefix.$attributeCode)
+                : $category->getData($attributeCode);
+            $value = Mage::getResourceSingleton('algoliasearch/fulltext')->getAttributeValue($attributeCode, $value, $storeId, Mage_Catalog_Model_Category::ENTITY);
             if ($value) {
                 $data[$attributeCode] = $value;
             }

--- a/code/Model/Resource/Fulltext.php
+++ b/code/Model/Resource/Fulltext.php
@@ -175,11 +175,16 @@ class Algolia_Algoliasearch_Model_Resource_Fulltext extends Mage_CatalogSearch_M
         }
 
         if (is_array($value)) {
-            $value = implode($this->_separator, $value);
+            return array_map(array($this, '_cleanData'), $value);
         } elseif (empty($value) && ($inputType == 'select' || $inputType == 'multiselect')) {
             return NULL;
         }
 
+        return $this->_cleanData($value);
+    }
+
+    protected function _cleanData($value)
+    {
         return preg_replace("#\s+#siu", ' ', trim(strip_tags($value)));
     }
 }


### PR DESCRIPTION
- Index arrays instead of converting them into strings with separator.
- Add data prefix to retrieve Algolia search specific data for the entity.

Example of using prefixes:
1. Add 'catalog_category_load_after' event.
2. $category->setAlgoliaSpecialAttributes(array_map('trim', explode(',', $category->getSpecialAttributes())));
So "algolia_special_attributes" category data will be used instead of "special_attributes".
