### PR TITLE
Skin not existing queries.

### DIFF
--- a/code/Model/Resource/Fulltext.php
+++ b/code/Model/Resource/Fulltext.php
@@ -103,6 +103,9 @@ class Algolia_Algoliasearch_Model_Resource_Fulltext extends Mage_CatalogSearch_M
         if ($queryId instanceof Mage_CatalogSearch_Model_Query) {
             $queryId = $queryId->getId();
         }
+        if ( ! $queryId) {
+            return FALSE;
+        }
         $adapter = $this->_getReadAdapter();
         $select = $adapter->select()->forUpdate(TRUE)
             ->from(array('query' => $this->getTable('catalogsearch/search_query')), array('query_id'))


### PR DESCRIPTION
A few times (should be a native Magento bug) not existing queries submitted to prepare search results so added sanity check to prevent FK errors. Native Magento does not generate the FK exception but saves query into "catalogsearch_query" table with no results so no reason to keep unsaved queries at all.
