### PR TITLE
Fix PHP fatal error when use catalog product flat.

### DIFF
--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -430,7 +430,6 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
                                 ->addOrderedQty()
                                 ->setStoreId($storeId)
                                 ->addStoreFilter($storeId)
-                                ->addAttributeToSelect(array('name', 'id'))
                                 ->addFieldToFilter('entity_id', $product->getId())
                                 ->getFirstItem();
                             $json['popularity'] = intval($report->getOrderedQty());


### PR DESCRIPTION
http://screencast.com/t/snnwChlwNTD

Error:

SELECT SUM(order_items.qty_ordered) AS `ordered_qty`, `order_items`.`name` AS `order_items_name`, `order_items`.`product_id` AS `entity_id`, `e`.`entity_type_id`, `e`.`attribute_set_id`, `e`.`type_id`, `e`.`sku`, `e`.`has_options`, `e`.`required_options`, `e`.`created_at`, `e`.`updated_at`, `e`.`name` FROM `sales_flat_order_item` AS `order_items`
 INNER JOIN `sales_flat_order` AS `order` ON `order`.entity_id = order_items.order_id AND `order`.state <> 'canceled'
 LEFT JOIN `catalog_product_entity` AS `e` ON (e.type_id NOT IN ('grouped', 'configurable', 'bundle')) AND e.entity_id = order_items.product_id AND e.entity_type_id = 4 WHERE (parent_item_id IS NULL) AND (e.entity_id = '4775') GROUP BY `order_items`.`product_id` HAVING (SUM(order_items.qty_ordered) > 0)

SQLSTATE[42S22]: Column not found: 1054 Unknown column 'e.name' in 'field list'
