### PR TITLE
Use cookie to save last query (optional feature disabled by default).

### DIFF
--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -10,6 +10,7 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
     const XML_PATH_MINIMAL_QUERY_LENGTH = 'algoliasearch/ui/minimal_query_length';
     const XML_PATH_SEARCH_DELAY         = 'algoliasearch/ui/search_delay';
     const XML_PATH_NUMBER_SUGGESTIONS   = 'algoliasearch/ui/number_suggestions';
+    const XML_PATH_SAVE_LAST_QUERY      = 'algoliasearch/ui/save_last_query';
 
     const XML_PATH_IS_ALGOLIA_SEARCH_ENABLED     = 'algoliasearch/settings/is_enabled';
     const XML_PATH_IS_POPUP_ENABLED              = 'algoliasearch/settings/is_popup_enabled';
@@ -716,6 +717,11 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
     public function getSearchDelay($storeId = NULL)
     {
         return (int) Mage::getStoreConfig(self::XML_PATH_SEARCH_DELAY, $storeId);
+    }
+
+    public function getSaveLastQuery($storeId = NULL)
+    {
+        return Mage::getStoreConfigFlag(self::XML_PATH_SAVE_LAST_QUERY, $storeId);
     }
 
     public function isEnabled($storeId = NULL)

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -164,6 +164,16 @@
                             <show_in_store>1</show_in_store>
                             <comment>Delay in milliseconds before a query is submitted to avoid excessive queries. Default value is 0 milliseconds.</comment>
                         </search_delay>
+                        <save_last_query translate="label comment">
+                            <label>Save Last Query</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>If enabled, the search query will be saved in a cookie when navigating to a search result page (it will not be saved if page is refreshed or other page is loaded).</comment>
+                        </save_last_query>
                     </fields>
                 </ui>
                 <queue translate="label">

--- a/design/frontend/template/topsearch.phtml
+++ b/design/frontend/template/topsearch.phtml
@@ -90,6 +90,14 @@ var algoliaLiveSearch = new AlgoliaLiveSearch({
             }
             $('search_autocomplete_products').update(html);
         }
+        <?php if ($algoliaSearchHelper->getSaveLastQuery()): ?>
+        $('search_autocomplete').select('a').invoke('observe', 'click', function(e){
+            var searchQuery = algoliaLiveSearch.searchForm.field.getValue();
+            if(searchQuery){
+                Mage.Cookies.set('lastSearchQuery', searchQuery);
+            }
+        });
+        <?php endif ?>
     },
     clearResults: function() {
         $('search_autocomplete_categories').update('');

--- a/skin/livesearch.js
+++ b/skin/livesearch.js
@@ -37,6 +37,11 @@ AlgoliaLiveSearch.prototype = {
             .observe('blur', this.options.clearResults ? this.options.clearResults.bind(this) : function(){})
             .observe('blur', this.focusOutCallback)
             .observe('keydown', this.onKeyPress.bindAsEventListener(this));
+
+        if (Mage && Mage.Cookies && Mage.Cookies.get('lastSearchQuery')) {
+            this.searchForm.field.value = Mage.Cookies.get('lastSearchQuery');
+            Mage.Cookies.set('lastSearchQuery', '');
+        }
     },
     submitSearch: function(event) {
         if (this.searchTimeoutId) {


### PR DESCRIPTION
Note, the last query is only saved for the page loads when the user clicks a search result. It will not be saved between pages refreshes or if a link that is not a search result is clicked.
