### PR TITLE
Improve lock contention with "Use Result Cache" option.

### DIFF
--- a/code/Model/Mysql4/Fulltext/Collection.php
+++ b/code/Model/Mysql4/Fulltext/Collection.php
@@ -1,0 +1,6 @@
+<?php
+
+class Algolia_Algoliasearch_Model_Mysql_Fulltext_Collection extends Algolia_Algoliasearch_Model_Resource_Fulltext_Collection
+{
+
+}

--- a/code/Model/Resource/Fulltext.php
+++ b/code/Model/Resource/Fulltext.php
@@ -32,10 +32,12 @@ class Algolia_Algoliasearch_Model_Resource_Fulltext extends Mage_CatalogSearch_M
      */
     public function prepareResult($object, $queryText, $query)
     {
+        Varien_Profiler::start('Algolia/FullText-prepareResult');
         try {
             $this->beginTransaction();
             if ( ! $this->lockQueryForTransaction($query)) {
                 $this->commit();
+                Varien_Profiler::stop('Algolia/FullText-prepareResult');
                 return $this;
             }
 
@@ -43,9 +45,11 @@ class Algolia_Algoliasearch_Model_Resource_Fulltext extends Mage_CatalogSearch_M
             if ( ! $this->_helper->isEnabled()) {
                 parent::prepareResult($object, $queryText, $query);
                 $this->commit();
+                Varien_Profiler::stop('Algolia/FullText-prepareResult');
                 return $this;
             }
 
+            Varien_Profiler::start('Algolia/FullText-prepareResult-process');
             if (!$query->getIsProcessed())
             {
 
@@ -120,6 +124,8 @@ class Algolia_Algoliasearch_Model_Resource_Fulltext extends Mage_CatalogSearch_M
             $this->rollBack();
             Mage::logException($e);
         }
+        Varien_Profiler::stop('Algolia/FullText-prepareResult-process');
+        Varien_Profiler::stop('Algolia/FullText-prepareResult');
 
         return $this;
     }

--- a/code/Model/Resource/Fulltext/Collection.php
+++ b/code/Model/Resource/Fulltext/Collection.php
@@ -1,0 +1,36 @@
+<?php
+
+class Algolia_Algoliasearch_Model_Resource_Fulltext_Collection extends Mage_CatalogSearch_Model_Resource_Fulltext_Collection
+{
+
+    /**
+     * Add search query filter without preparing result since result table causes lots of lock contention.
+     *
+     * @param string $query
+     * @throws Exception
+     * @return Mage_CatalogSearch_Model_Resource_Fulltext_Collection
+     */
+    public function addSearchFilter($query)
+    {
+        if ( ! Mage::helper('algoliasearch')->isEnabled() || Mage::helper('algoliasearch')->useResultCache()) {
+            return parent::addSearchFilter($query);
+        }
+
+        // This method of filtering the product collection by the search result does not use the catalogsearch_result table
+        try {
+            $data = Mage::helper('algoliasearch')->getSearchResult($query, Mage::app()->getStore()->getId());
+        } catch (Exception $e) {
+            Mage::getSingleton('catalog/session')->addError(Mage::helper('algoliasearch')->__('Search failed. Please try again.'));
+            $this->getSelect()->columns(['relevance' => new Zend_Db_Expr("e.entity_id")]);
+            $this->getSelect()->where('e.entity_id = 0');
+            return $this;
+        }
+
+        $sortedIds = array_reverse(array_keys($data));
+        $this->getSelect()->columns(['relevance' => new Zend_Db_Expr("FIND_IN_SET(e.entity_id, '".implode(',',$sortedIds)."')")]);
+        $this->getSelect()->where('e.entity_id IN (?)', $sortedIds);
+
+        return $this;
+    }
+
+}

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -52,11 +52,13 @@
             <catalogsearch_mysql4>
                 <rewrite>
                     <fulltext>Algolia_Algoliasearch_Model_Mysql4_Fulltext</fulltext>
+                    <fulltext_collection>Algolia_Algoliasearch_Model_Mysql4_Fulltext_Collection</fulltext_collection>
                 </rewrite>
             </catalogsearch_mysql4>
             <catalogsearch_resource>
                 <rewrite>
                     <fulltext>Algolia_Algoliasearch_Model_Resource_Fulltext</fulltext>
+                    <fulltext_collection>Algolia_Algoliasearch_Model_Resource_Fulltext_Collection</fulltext_collection>
                 </rewrite>
             </catalogsearch_resource>
             <enterprise_search>

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -146,6 +146,15 @@
                             <show_in_store>1</show_in_store>
                             <comment>The maximum number of results to return for searches. Maximum is 1000.</comment>
                         </results_limit>
+                        <use_result_cache translate="label comment">
+                            <label>Use Result Cache</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>110</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <comment>The Result Cache (catalogsearch_result table, prepareResult method) can reduce the number of repeat queries, but may also cause high database load and/or lock contention if products are saved frequently..</comment>
+                            <depends><is_enabled>1</is_enabled></depends>
+                        </use_result_cache>
                     </fields>
                 </settings>
                 <ui translate="label">

--- a/design/frontend/template/topsearch.phtml
+++ b/design/frontend/template/topsearch.phtml
@@ -69,8 +69,10 @@ var algoliaLiveSearch = new AlgoliaLiveSearch({
                     '<div class="clearfix"></div>' +
                     '</a>';
             }
-            $('search_autocomplete_categories').update(html);
+        } else {
+            html = '';
         }
+        $('search_autocomplete_categories').update(html);
 
         // Display products
         if (displayProducts) {
@@ -90,15 +92,18 @@ var algoliaLiveSearch = new AlgoliaLiveSearch({
             } else {
                 html += '<div><?php echo $this->__('No results.') ?></div>'
             }
-            $('search_autocomplete_products').update(html);
+        } else {
+            html = '';
         }
+        $('search_autocomplete_products').update(html);
+
         <?php if ($algoliaSearchHelper->getSaveLastQuery()): ?>
-        $('search_autocomplete').select('a').invoke('observe', 'click', function(e){
-            var searchQuery = algoliaLiveSearch.searchForm.field.getValue();
-            if(searchQuery){
+        var searchQuery = algoliaLiveSearch.searchForm.field.getValue();
+        if(searchQuery){
+            $('search_autocomplete').select('a').invoke('observe', 'click', function(e){
                 Mage.Cookies.set('lastSearchQuery', searchQuery);
-            }
-        });
+            });
+        }
         <?php endif ?>
     },
     clearResults: function() {

--- a/skin/livesearch.js
+++ b/skin/livesearch.js
@@ -88,10 +88,10 @@ AlgoliaLiveSearch.prototype = {
     onKeyPress: function(event) {
         if(this.active)
             switch(event.keyCode) {
-                case Event.KEY_TAB:
                 case Event.KEY_RETURN:
                     this.selectEntry();
                     Event.stop(event);
+                    return;
                 case Event.KEY_ESC:
                     this.searchForm.field.blur();
                     Event.stop(event);
@@ -103,6 +103,7 @@ AlgoliaLiveSearch.prototype = {
                     this.markPrevious();
                     Event.stop(event);
                     return;
+                case Event.KEY_TAB:
                 case Event.KEY_DOWN:
                     this.markNext();
                     Event.stop(event);


### PR DESCRIPTION
Magento is designed to save the results of a query into the catalogsearch_result table, but these results get cleared so frequently and the use of this table creates so much additional lock contention and Algolia is so fast that this method really doesn't make sense. This pull request causes the default behavior to bypass the use of this table which actually makes loading the results page much faster and reduces database load and most importantly, lock contention with other important things like submitting orders.