### PR TITLE
Fix getProductJSON for listener's data and price type

### DIFF
--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -312,6 +312,10 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
         }
         $customData = array_merge($customData, $defaultData);
 
+        if (isset($customData['price'])) {
+            $customData['price'] = floatval($customData['price']);
+        }
+
         return $customData;
     }
 

--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -274,6 +274,8 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
     {
         $transport = new Varien_Object($defaultData);
         Mage::dispatchEvent('algolia_product_index_before', array('product' => $product, 'custom_data' => $transport));
+        $defaultData = $transport->getData();
+
         $defaultData = is_array($defaultData) ? $defaultData : explode("|",$defaultData);
 
         $categories = array();


### PR DESCRIPTION
Injected data by a listener to the algolia_product_index_before event were not used is the method.
The price should be sent as float to ensure Algolia engine is using it as a numerical value for ranges & sliders.