### PR TITLE
Support Magento installs that use prefixed MySQL tables

### DIFF
--- a/code/Model/Resource/Fulltext.php
+++ b/code/Model/Resource/Fulltext.php
@@ -70,7 +70,7 @@ class Algolia_Algoliasearch_Model_Resource_Fulltext extends Mage_CatalogSearch_M
                 // from catalog but not yet from index). Avoids foreign key errors and incorrect listings
                 if ($data) {
                     $existingProductIds = $this->_getWriteAdapter()->fetchCol($this->_getWriteAdapter()->select()
-                        ->from($this->_getWriteAdapter()->getTableName('catalog_product_website'), array('product_id'))
+                        ->from(Mage::getSingleton('core/resource')->getTableName('catalog_product_website'), array('product_id'))
                         ->where('website_id = ?', Mage::app()->getStore($query->getStoreId())->getWebsiteId())
                         ->where('product_id IN (?)', array_keys($data))
                     );


### PR DESCRIPTION
Using `$this->_getWriteAdapter()` to grab a table name does not work for Magento installs that have prefixed MySQL tables (specified in `app/etc/local.xml`, under the node `config > global > resources > db > table_prefix`). To correctly retrieve the table's name, we need to go through the Magento DB singleton, which has more knowledge about Magento's internals and returns the correct, prefixed, table name.

All other uses of `$this->getWriteAdapter()` in the file seem to be fine since they aren't used to grab table names.