### PR TITLE
changed how product filter gets products with visiblity search or catalog, search

### DIFF
--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -512,7 +512,7 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
 
         $customData['ordered_qty']      = intval($report->getOrderedQty());
         $customData['stock_qty']        = (int) Mage::getModel('cataloginventory/stock_item')->loadByProduct($product)->getQty();
-        
+
         if ($product->getTypeId() == 'configurable')
         {
             $sub_products   = $product->getTypeInstance(true)->getUsedProducts(null, $product);
@@ -836,7 +836,7 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
             $products
                 ->setStoreId($storeId)
                 ->addStoreFilter($storeId)
-                ->setVisibility(Mage::getSingleton('catalog/product_visibility')->getVisibleInSearchIds())
+                ->addAttributeToFilter('visibility', array('in' => Mage::getSingleton('catalog/product_visibility')->getVisibleInSearchIds()))
                 ->addFinalPrice()
                 ->addAttributeToFilter('status', Mage_Catalog_Model_Product_Status::STATUS_ENABLED)
                 ->addAttributeToSelect(array_merge(self::$_predefinedProductAttributes, $additionalAttr))


### PR DESCRIPTION
Old product collection filtering method only retrieved products with visibility "catalog, search". Products with visibility "search" were not being included for whatever reason. Filtering the product collection this other way will instead get products with visibility "search" or "catalog, search".