### PR TITLE
Loading helper classes via magento helper loader

### DIFF
--- a/code/Block/System/Config/Form/Field/Customrankingcategory.php
+++ b/code/Block/System/Config/Form/Field/Customrankingcategory.php
@@ -18,7 +18,7 @@ class Algolia_Algoliasearch_Block_System_Config_Form_Field_Customrankingcategory
     {
         if (!array_key_exists($columnId, $this->selectFields) || !$this->selectFields[$columnId])
         {
-            $config = new Algolia_Algoliasearch_Helper_Config();
+            $config = Mage::helper('algoliasearch/config');
 
             $aOptions = array();
 

--- a/code/Block/System/Config/Form/Field/Customrankingproduct.php
+++ b/code/Block/System/Config/Form/Field/Customrankingproduct.php
@@ -18,7 +18,7 @@ class Algolia_Algoliasearch_Block_System_Config_Form_Field_Customrankingproduct 
     {
         if (!array_key_exists($columnId, $this->selectFields) || !$this->selectFields[$columnId])
         {
-            $config = new Algolia_Algoliasearch_Helper_Config();
+            $config = Mage::helper('algoliasearch/config');
 
             $aOptions = array();
 

--- a/code/Block/System/Config/Form/Field/Customsortordercategory.php
+++ b/code/Block/System/Config/Form/Field/Customsortordercategory.php
@@ -18,7 +18,7 @@ class Algolia_Algoliasearch_Block_System_Config_Form_Field_Customsortordercatego
     {
         if (!array_key_exists($columnId, $this->selectFields) || !$this->selectFields[$columnId])
         {
-            $category_helper = new Algolia_Algoliasearch_Helper_Entity_Categoryhelper();
+            $category_helper = Mage::helper('algoliasearch/entity_categoryhelper');
 
             $aOptions = array();
 

--- a/code/Block/System/Config/Form/Field/Customsortorderproduct.php
+++ b/code/Block/System/Config/Form/Field/Customsortorderproduct.php
@@ -18,7 +18,7 @@ class Algolia_Algoliasearch_Block_System_Config_Form_Field_Customsortorderproduc
     {
         if (!array_key_exists($columnId, $this->selectFields) || !$this->selectFields[$columnId])
         {
-            $product_helper = new Algolia_Algoliasearch_Helper_Entity_Producthelper();
+            $product_helper = Mage::helper('algoliasearch/entity_producthelper');
 
             $aOptions = array();
 

--- a/code/Block/System/Config/Form/Field/Facets.php
+++ b/code/Block/System/Config/Form/Field/Facets.php
@@ -10,7 +10,7 @@ class Algolia_Algoliasearch_Block_System_Config_Form_Field_Facets extends Mage_A
     protected function getRenderer($columnId) {
         if (!array_key_exists($columnId, $this->selectFields) || !$this->selectFields[$columnId])
         {
-            $product_helper = new Algolia_Algoliasearch_Helper_Entity_Producthelper();
+            $product_helper = Mage::helper('algoliasearch/entity_producthelper');
 
             $aOptions = array();
 

--- a/code/Block/System/Config/Form/Field/Sorts.php
+++ b/code/Block/System/Config/Form/Field/Sorts.php
@@ -17,7 +17,7 @@ class Algolia_Algoliasearch_Block_System_Config_Form_Field_Sorts extends Mage_Ad
     protected function getRenderer($columnId) {
         if (!array_key_exists($columnId, $this->selectFields) || !$this->selectFields[$columnId])
         {
-            $product_helper = new Algolia_Algoliasearch_Helper_Entity_Producthelper();
+            $product_helper = Mage::helper('algoliasearch/entity_producthelper');
 
             $aOptions = array();
 

--- a/code/Helper/Algoliahelper.php
+++ b/code/Helper/Algoliahelper.php
@@ -15,7 +15,7 @@ class Algolia_Algoliasearch_Helper_Algoliahelper extends Mage_Core_Helper_Abstra
 
     public function __construct()
     {
-        $config = new Algolia_Algoliasearch_Helper_Config();
+        $config = Mage::helper('algoliasearch/config');
 
         if ($config->getApplicationID() && $config->getAPIKey())
             $this->client = new \AlgoliaSearch\Client($config->getApplicationID(), $config->getAPIKey());

--- a/code/Helper/Config.php
+++ b/code/Helper/Config.php
@@ -140,7 +140,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
 
     public function getSortingIndices($storeId = NULL)
     {
-        $product_helper = new Algolia_Algoliasearch_Helper_Entity_Producthelper();
+        $product_helper = Mage::helper('algoliasearch/entity_producthelper');
 
         $attrs = unserialize(Mage::getStoreConfig(self::XML_PATH_SORTING_INDICES, $storeId));
 

--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -13,25 +13,25 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
 {
     const COLLECTION_PAGE_SIZE = 100;
 
-    private $algolia_helper;
+    protected $algolia_helper;
 
-    private $page_helper;
-    private $category_helper;
-    private $product_helper;
+    protected $page_helper;
+    protected $category_helper;
+    protected $product_helper;
 
-    private $config;
+    protected $config;
 
     public function __construct()
     {
         \AlgoliaSearch\Version::$custom_value = " Magento (1.2.0)";
 
-        $this->algolia_helper   = new Algolia_Algoliasearch_Helper_Algoliahelper();
+        $this->algolia_helper   = Mage::helper('algoliasearch/algoliahelper');
 
-        $this->page_helper      = new Algolia_Algoliasearch_Helper_Entity_Pagehelper();
-        $this->category_helper  = new Algolia_Algoliasearch_Helper_Entity_Categoryhelper();
-        $this->product_helper   = new Algolia_Algoliasearch_Helper_Entity_Producthelper();
+        $this->page_helper      = Mage::helper('algoliasearch/entity_pagehelper');
+        $this->category_helper  = Mage::helper('algoliasearch/entity_categoryhelper');
+        $this->product_helper   = Mage::helper('algoliasearch/entity_producthelper');
 
-        $this->config           = new Algolia_Algoliasearch_Helper_Config();
+        $this->config           = Mage::helper('algoliasearch/config');
     }
 
     public function deleteStoreIndices($storeId = null)

--- a/code/Helper/Entity/Helper.php
+++ b/code/Helper/Entity/Helper.php
@@ -13,8 +13,8 @@ abstract class Algolia_Algoliasearch_Helper_Entity_Helper
 
     public function __construct()
     {
-        $this->config           = new Algolia_Algoliasearch_Helper_Config();
-        $this->algolia_helper   = new Algolia_Algoliasearch_Helper_Algoliahelper();
+        $this->config           = Mage::helper('algoliasearch/config');
+        $this->algolia_helper   = Mage::helper('algoliasearch/algoliahelper');
     }
 
     public function getBaseIndexName($storeId = null)

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -81,7 +81,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         foreach ($additionalAttr as &$attr)
             $attr = $attr['attribute'];
 
-        $products = $products->addAttributeToSelect(array_merge(self::$_predefinedProductAttributes, $additionalAttr));
+        $products = $products->addAttributeToSelect(array_merge(static::$_predefinedProductAttributes, $additionalAttr));
 
         if ($productIds && count($productIds) > 0)
             $products->addAttributeToFilter('entity_id', array('in' => $productIds));

--- a/code/Model/Indexer/Algolia.php
+++ b/code/Model/Indexer/Algolia.php
@@ -32,7 +32,7 @@ class Algolia_Algoliasearch_Model_Indexer_Algolia extends Mage_Index_Model_Index
         parent::__construct();
 
         $this->engine = new Algolia_Algoliasearch_Model_Resource_Engine();
-        $this->config = new Algolia_Algoliasearch_Helper_Config();
+        $this->config = Mage::helper('algoliasearch/config');
     }
 
     protected $_matchedEntities = array(

--- a/code/Model/Observer.php
+++ b/code/Model/Observer.php
@@ -11,9 +11,9 @@ class Algolia_Algoliasearch_Model_Observer
 
     public function __construct()
     {
-        $this->config           = new Algolia_Algoliasearch_Helper_Config();
-        $this->product_helper   = new Algolia_Algoliasearch_Helper_Entity_Producthelper();
-        $this->category_helper  = new Algolia_Algoliasearch_Helper_Entity_Categoryhelper();
+        $this->config           = Mage::helper('algoliasearch/config');
+        $this->product_helper   = Mage::helper('algoliasearch/entity_producthelper');
+        $this->category_helper  = Mage::helper('algoliasearch/entity_categoryhelper');
 
         $this->helper           = Mage::helper('algoliasearch');
     }

--- a/code/Model/Queue.php
+++ b/code/Model/Queue.php
@@ -15,7 +15,7 @@ class Algolia_Algoliasearch_Model_Queue
         $this->table = Mage::getSingleton('core/resource')->getTableName('algoliasearch/queue');
         $this->db = Mage::getSingleton('core/resource')->getConnection('core_write');
 
-        $this->config = new Algolia_Algoliasearch_Helper_Config();
+        $this->config = Mage::helper('algoliasearch/config');
     }
 
     public function add($class, $method, $data, $retries = NULL)

--- a/code/Model/Resource/Engine.php
+++ b/code/Model/Resource/Engine.php
@@ -17,8 +17,8 @@ class Algolia_Algoliasearch_Model_Resource_Engine extends Mage_CatalogSearch_Mod
 
         $this->queue = Mage::getSingleton('algoliasearch/queue');
         $this->config = new Algolia_Algoliasearch_Helper_Config();
-        $this->product_helper = new Algolia_Algoliasearch_Helper_Entity_Producthelper();
-        $this->category_helper = new Algolia_Algoliasearch_Helper_Entity_Categoryhelper();
+        $this->product_helper = Mage::helper('algoliasearch/entity_producthelper');
+        $this->category_helper = Mage::helper('algoliasearch/entity_categoryhelper');
     }
 
     public function addToQueue($observer, $method, $data, $nb_retry)

--- a/code/Model/Resource/Engine.php
+++ b/code/Model/Resource/Engine.php
@@ -16,7 +16,7 @@ class Algolia_Algoliasearch_Model_Resource_Engine extends Mage_CatalogSearch_Mod
         parent::_construct();
 
         $this->queue = Mage::getSingleton('algoliasearch/queue');
-        $this->config = new Algolia_Algoliasearch_Helper_Config();
+        $this->config = Mage::helper('algoliasearch/config');
         $this->product_helper = Mage::helper('algoliasearch/entity_producthelper');
         $this->category_helper = Mage::helper('algoliasearch/entity_categoryhelper');
     }

--- a/code/Model/Resource/Fulltext/Collection.php
+++ b/code/Model/Resource/Fulltext/Collection.php
@@ -7,11 +7,11 @@ class Algolia_Algoliasearch_Model_Resource_Fulltext_Collection extends Mage_Cata
      */
     public function addSearchFilter($query)
     {
-        $config = new Algolia_Algoliasearch_Helper_Config();
+        $config = Mage::helper('algoliasearch/config');
 
         if ($config->isInstantEnabled() && Mage::app()->getRequest()->getParam('instant') == null)
         {
-            $product_helper = new Algolia_Algoliasearch_Helper_Entity_Producthelper();
+            $product_helper = Mage::helper('algoliasearch/entity_producthelper');
 
             $url = Mage::getBaseUrl().'catalogsearch/result/?q='.$query.'&instant=1#q='.$query.'&page=0&refinements=%5B%5D&numerics_refinements=%7B%7D&index_name=%22'.$product_helper->getIndexName().'%22';
 

--- a/design/frontend/template/topsearch.phtml
+++ b/design/frontend/template/topsearch.phtml
@@ -1,8 +1,8 @@
 <?php
-$config = new Algolia_Algoliasearch_Helper_Config();
+$config = Mage::helper('algoliasearch/config');
 $catalogSearchHelper = $this->helper('catalogsearch'); /** @var $catalogSearchHelper Mage_CatalogSearch_Helper_Data */
 $algoliaSearchHelper = $this->helper('algoliasearch'); /** @var $algoliaSearchHelper Algolia_Algoliasearch_Helper_Data */
-$product_helper = new Algolia_Algoliasearch_Helper_Entity_Producthelper();
+$product_helper = Mage::helper('algoliasearch/entity_producthelper');
 $isSearchPage = Mage::app()->getRequest()->getParam('instant') != null || Mage::app()->getRequest()->getParam('category') != null;
 
 if ($config->isInstantEnabled() && $isSearchPage) {


### PR DESCRIPTION
Looks like v1.2.0 is loading helper classes directly by name as opposed to using Magento's helper loader, preventing extension of the Algolia helper classes without some tedious modifying of several classes.

`$this->product_helper   = new Algolia_Algoliasearch_Helper_Entity_Producthelper();`
vs
`$this->product_helper   = Mage::helper('algoliasearch/entity_producthelper');`

Also, changed a few more private variables to protected.