### PR TITLE
Event to add additional data for child products

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -576,6 +576,10 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
             }
         }
 
+        $transport = new Varien_Object($customData);
+        Mage::dispatchEvent('algolia_subproducts_index', array('custom_data' => $transport, 'sub_products' => $sub_products));
+        $customData = $transport->getData();
+
         $customData = array_merge($customData, $defaultData);
 
         $customData['type_id'] = $product->getTypeId();


### PR DESCRIPTION
Adds a new event to allow observers to extract additional data from the
collection of sub products and add to the index. This can be used for
example, to add images URLs of child products that can later be used for
alternative images