### PR TITLE
Disabling the Mage_Review-module caused the indexing not to run

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -505,14 +505,17 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         }
 
 
-        if ($this->isAttributeEnabled($additionalAttributes, 'rating_summary'))
+        if (Mage::helper('core')->isModuleEnabled('Mage_Review'))
         {
-            $summaryData = Mage::getModel('review/review_summary')
-                ->setStoreId($product->getStoreId())
-                ->load($product->getId());
+            if ($this->isAttributeEnabled($additionalAttributes, 'rating_summary'))
+            {
+                $summaryData = Mage::getModel('review/review_summary')
+                    ->setStoreId($product->getStoreId())
+                    ->load($product->getId());
 
-            if ($summaryData['rating_summary'])
-                $customData['rating_summary'] = $summaryData['rating_summary'];
+                if ($summaryData['rating_summary'])
+                    $customData['rating_summary'] = $summaryData['rating_summary'];
+            }
         }
 
         foreach ($additionalAttributes as $attribute)


### PR DESCRIPTION
Fixed a bug where having the Mage_Review-module disabled caused the indexing not to run.

Added a simple check for this. Runs without problems now.