### PR TITLE
Handling configurable, bundles and grouped products without options

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -409,7 +409,12 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                 }, $sub_products);
             }
 
-            $sub_products = $this->getProductCollectionQuery($product->getStoreId(), $ids, false)->load();
+            if (count($ids)) {
+                $sub_products = $this->getProductCollectionQuery($product->getStoreId(), $ids, false)->load();
+            }
+            else {
+                $sub_products = array();
+            }
 
             if ($product->getTypeId() == 'grouped' || $product->getTypeId() == 'configurable')
             {


### PR DESCRIPTION
If the configurable, bundles or grouped products doesn't have any sub products. The $ids variable ends up beeing empty. This will result that the getProductCollectionQuery will return the whole product catalog as sub_products.