### PR TITLE
Settings for image size and image type

### DIFF
--- a/code/Helper/Config.php
+++ b/code/Helper/Config.php
@@ -49,6 +49,10 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     const NUMBER_OF_JOB_TO_RUN                 = 'algoliasearch/queue/number_of_job_to_run';
     const NO_PROCESS                           = 'algoliasearch/queue/noprocess';
 
+    const XML_PATH_IMAGE_WIDTH                 = 'algoliasearch/image/width';
+    const XML_PATH_IMAGE_HEIGHT                = 'algoliasearch/image/height';
+    const XML_PATH_IMAGE_TYPE                  = 'algoliasearch/image/type';
+
     const PARTIAL_UPDATES                      = 'algoliasearch/advanced/partial_update';
     const CUSTOMER_GROUPS_ENABLE               = 'algoliasearch/advanced/customer_groups_enable';
     const MAKE_SEO_REQUEST                     = 'algoliasearch/advanced/make_seo_request';
@@ -85,6 +89,21 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     public function noProcess($storeId = null)
     {
         return Mage::getStoreConfigFlag(self::NO_PROCESS, $storeId);
+    }
+
+    public function getImageWidth($storeId = null)
+    {
+        return Mage::getStoreConfig(self::XML_PATH_IMAGE_WIDTH, $storeId);
+    }
+
+    public function getImageHeight($storeId = null)
+    {
+        return Mage::getStoreConfig(self::XML_PATH_IMAGE_HEIGHT, $storeId);
+    }
+
+    public function getImageType($storeId = null)
+    {
+        return Mage::getStoreConfig(self::XML_PATH_IMAGE_TYPE, $storeId);
     }
 
     public function isCustomerGroupsEnabled($storeId = null)

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -4,7 +4,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 {
     protected static $_productAttributes;
 
-    protected static $_predefinedProductAttributes = array('name', 'url_key', 'description', 'image', 'thumbnail');
+    protected static $_predefinedProductAttributes = array('name', 'url_key', 'description', 'image', 'small_image', 'thumbnail');
 
     protected function getIndexNameSuffix()
     {
@@ -488,7 +488,9 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         {
             try
             {
-                $customData['image_url'] = Mage::getModel('catalog/product_media_config')->getMediaUrl($product->getImage());
+                $customData['image_url'] = (string)
+                    Mage::helper('catalog/image')->init($product, $this->config->getImageType())
+                    ->resize($this->config->getImageWidth(), $this->config->getImageHeight());
                 $customData['image_url'] = str_replace(array('https://', 'http://'), '//', $customData['image_url']);
             }
             catch (\Exception $e) {}

--- a/code/Model/System/Imagetype.php
+++ b/code/Model/System/Imagetype.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Source model for select image type
+ */
+
+class Algolia_Algoliasearch_Model_System_Imagetype
+{
+    public function toOptionArray()
+    {
+        return array(
+            array('value'=>'image',         'label' => Mage::helper('core')->__('Base Image')),
+            array('value'=>'small_image',   'label' => Mage::helper('core')->__('Small Image')),
+            array('value'=>'thumbnail',     'label' => Mage::helper('core')->__('Thumbnail')),
+        );
+    }
+}

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -175,6 +175,11 @@
                 <number_of_job_to_run>300</number_of_job_to_run>
                 <noprocess>0</noprocess>
             </queue>
+            <image>
+                <width>265</width>
+                <height>265</height>
+                <type>image</type>
+            </image>
             <advanced>
                 <partial_update>0</partial_update>
                 <make_seo_request>1</make_seo_request>

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -572,11 +572,52 @@
                         </noprocess>
                     </fields>
                 </queue>
+                <image translate="label">
+                    <label>Image Configuration</label>
+                    <expanded>1</expanded>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>80</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <width translate="label comment">
+                            <label>Width</label>
+                            <frontend_type>text</frontend_type>
+                            <validate>validate-digits</validate>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </width>
+                        <height translate="label comment">
+                            <label>Height</label>
+                            <frontend_type>text</frontend_type>
+                            <validate>validate-digits</validate>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[You can specify the size of the images used at the Search Results Page.<br />
+                                If your images are already present in some size, eg. 265x265, Algolia's index job may not have to resize those, potentially saving time and resources.]]></comment>
+                        </height>
+                        <type translate="label comment">
+                            <label>Type</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>algoliasearch/system_imagetype</source_model>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>The image used at the Search Results Page.</comment>
+                        </type>
+                    </fields>
+                </image>
                 <advanced translate="label">
                     <label>Advanced Configuration</label>
                     <expanded>0</expanded>
                     <frontend_type>text</frontend_type>
-                    <sort_order>80</sort_order>
+                    <sort_order>90</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>


### PR DESCRIPTION
So, at my company we have had problems with indexing requiring just too much resources, and end up in undefined behavior. One of those have been placeholder images being indexed.

The proposed functionality would be to have a setting for image size. As many Magento stores already have a lot of images in a fixed size in the cache, eg. 265x265, it would be beneficial to let Algolia Search for Magento use those images as well, and thus maybe cut the resource use.

There is also a setting added for which product image to use: Base Image, Small Image or Thumbnail.