### PR TITLE
Making products mappable to standard Magento types

### DIFF
--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -180,6 +180,12 @@
                 <make_seo_request>1</make_seo_request>
                 <remove_branding>0</remove_branding>
             </advanced>
+            <product_map>
+                <!--
+                To map product types to standard Magento types, use the following syntax:
+                <kit>grouped</kit>
+                -->
+            </product_map>
         </algoliasearch>
     </default>
 </config> 


### PR DESCRIPTION
We have developed several custom product types for a client. These product types are built on Magento's standard product types and add extra functionality (but don't change how the original product works).

As it is, Algolia doesn't recognize these. I made a simple mapping configuration to be able to map custom product types to Magento product types.