### PR TITLE
Reindex after AvS_FastSimpleImport product import

### DIFF
--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -86,6 +86,16 @@
                     </algolia_stockupdate>
                 </observers>
             </catalog_product_save_before>
+
+            <fastsimpleimport_reindex_products_before_fulltext>
+                <observers>
+                    <algolia_search>
+                        <type>singleton</type>
+                        <class>algoliasearch/observer</class>
+                        <method>rebuildAfterFSIProductImport</method>
+                    </algolia_search>
+                </observers>
+            </fastsimpleimport_reindex_products_before_fulltext>
         </events>
         <resources>
             <algoliasearch_setup>


### PR DESCRIPTION
Is this the sort of thing you'd be willing to accept for #228 or would you prefer if I just kept this in my own module?

After AvSFastSimpleImport updates products, this will:
* Reindex the affected products.
* Reindex the current categories of the affected products.

It won’t:
* Reindex any categories that affected products were removed from.
* Remove products that are deleted. (it will remove disabled/not visible
in search)
* Do anything with category imports or category/product imports.