### PR TITLE
Changed image resize to avoid rewrite of catalog/image helper

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -480,7 +480,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
         if (false === isset($defaultData['thumbnail_url']))
         {
-            $thumb = Mage::helper('catalog/image')->init($product, 'thumbnail')->resize(75, 75);
+            $thumb = Mage::helper('algoliasearch/image')->init($product, 'thumbnail')->resize(75, 75);
 
             try
             {
@@ -499,7 +499,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
         if (false === isset($defaultData['image_url']))
         {
-            $image = Mage::helper('catalog/image')->init($product, $this->config->getImageType())->resize($this->config->getImageWidth(), $this->config->getImageHeight());
+            $image = Mage::helper('algoliasearch/image')->init($product, $this->config->getImageType())->resize($this->config->getImageWidth(), $this->config->getImageHeight());
 
             try
             {

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -30,11 +30,6 @@
             <algoliasearch>
                 <class>Algolia_Algoliasearch_Helper</class>
             </algoliasearch>
-            <catalog>
-                <rewrite>
-                    <image>Algolia_Algoliasearch_Helper_Image</image>
-                </rewrite>
-            </catalog>
         </helpers>
         <blocks>
             <algoliasearch>


### PR DESCRIPTION
Instead of doing a rewrite of catalog/image just use the algoliasearch/image helper directly in the code.

Doing rewrites will often cause conflicts with other modules so avoiding it is preferred.