### PR TITLE
Only add categories under the current root category

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -420,8 +420,18 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                 ->addFieldToFilter('level', array('gt' => 1))
                 ->addIsActiveFilter();
 
+            $rootCat = Mage::app()->getStore($product->getStoreId())->getRootCategoryId();
+
             foreach ($categoryCollection as $category)
             {
+                // Check and skip all categories that is not
+                // in the path of the current store.
+                $path = $category->getPath();
+                $path_parts = explode("/",$path);
+                if (isset($path_parts[1]) && $path_parts[1] != $rootCat) {
+                    continue;
+                }
+                
                 $categoryName = $category->getName();
 
                 if ($categoryName)


### PR DESCRIPTION
This will only index the categories under the current category for each store.

If you have several category trees for each store, and have the same products in multiple category trees this patch will prevent that all categories trees are indexed for each store. This will only index the categories that derive from the root category for the current store.