### PR TITLE
Set configurable product out of stock, if all the children is out of stock.

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -622,12 +622,16 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                     {
                         $values = array();
 
+                        $all_sub_product_out_of_stock = true;
+
                         foreach ($sub_products as $sub_product)
                         {
                             $stock = (int) $sub_product->getStockItem()->getIsInStock();
 
                             if ($stock == false)
                                 continue;
+
+                            $all_sub_product_out_of_stock = false;
 
                             $value = $sub_product->getData($attribute['attribute']);
 
@@ -646,7 +650,8 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                         {
                             $customData[$attribute['attribute']] = array_values(array_unique($values));
                         }
-                        else {
+
+                        if ($all_sub_products_out_of_stock) {
                             // Set main product out of stock if all
                             // sub-products is out of stock.
                             $customData['in_stock'] = 0;

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -651,7 +651,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                             $customData[$attribute['attribute']] = array_values(array_unique($values));
                         }
 
-                        if ($all_sub_products_out_of_stock) {
+                        if ($customData['in_stock'] && $all_sub_products_out_of_stock) {
                             // Set main product out of stock if all
                             // sub-products is out of stock.
                             $customData['in_stock'] = 0;

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -622,7 +622,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                     {
                         $values = array();
 
-                        $all_sub_product_out_of_stock = true;
+                        $all_sub_products_out_of_stock = true;
 
                         foreach ($sub_products as $sub_product)
                         {
@@ -631,7 +631,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                             if ($stock == false)
                                 continue;
 
-                            $all_sub_product_out_of_stock = false;
+                            $all_sub_products_out_of_stock = false;
 
                             $value = $sub_product->getData($attribute['attribute']);
 

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -646,6 +646,11 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                         {
                             $customData[$attribute['attribute']] = array_values(array_unique($values));
                         }
+                        else {
+                            // Set main product out of stock if all
+                            // sub-products is out of stock.
+                            $customData['in_stock'] = 0;
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
The Configurable product in Magento (or even grouped products) does not update the stockitem  automaticly when all the children is out of stock.

The check on line 588 will always be true as long as the status on the configurable product is set to "in stock":
$customData['in_stock'] = (int) $stockItem->getIsInStock();

Since Algolia is using this to see if the product is sellable or not, the configurable product should be set out of stock if all the sub products is out of stock.