### PR TITLE
Changed code to use Magento method calls instead of hard coded values

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -75,14 +75,8 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         $products = $products->setStoreId($storeId)
                         ->addStoreFilter($storeId);
 
-        /**
-         * const VISIBILITY_NOT_VISIBLE    = 1;
-         * const VISIBILITY_IN_CATALOG     = 2;
-         * const VISIBILITY_IN_SEARCH      = 3;
-         * const VISIBILITY_BOTH           = 4;
-         */
         if ($only_visible)
-            $products = $products->addAttributeToFilter('visibility', array('in' => array(2, 3, 4)));
+            $products = $products->addAttributeToFilter('visibility', array('in' => Mage::getSingleton('catalog/product_visibility')->getVisibleInSiteIds()));
 
         if (false === $this->config->getShowOutOfStock($storeId))
             Mage::getSingleton('cataloginventory/stock')->addInStockFilterToCollection($products);
@@ -441,12 +435,15 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
         $visibility = (int) $product->getVisibility();
 
+        $visibleInCatalog = Mage::getSingleton('catalog/product_visibility')->getVisibleInCatalogIds();
+        $visibleInSearch = Mage::getSingleton('catalog/product_visibility')->getVisibleInSearchIds();
+
         $customData = array(
             'objectID'          => $product->getId(),
             'name'              => $product->getName(),
             'url'               => Mage::getBaseUrl() . $product->getRequestPath(),
-            'visibility_search'  => (int) ($visibility === 3 || $visibility === 4),
-            'visibility_catalog' => (int) ($visibility === 2 || $visibility === 4)
+            'visibility_search'  => (int) (in_array($visibility, $visibleInSearch)),
+            'visibility_catalog' => (int) (in_array($visibility, $visibleInCatalog))
         );
 
         $additionalAttributes = $this->config->getProductAdditionalAttributes($product->getStoreId());

--- a/code/Model/Indexer/Algolia.php
+++ b/code/Model/Indexer/Algolia.php
@@ -131,12 +131,13 @@ class Algolia_Algoliasearch_Model_Indexer_Algolia extends Mage_Index_Model_Index
                 /** @var $product Mage_Catalog_Model_Product */
                 $product = $event->getDataObject();
                 $delete = FALSE;
+                $visibleInSite = Mage::getSingleton('catalog/product_visibility')->getVisibleInSiteIds();
 
                 if ($product->getStatus() == Mage_Catalog_Model_Product_Status::STATUS_DISABLED)
                 {
                     $delete = TRUE;
                 }
-                elseif (! in_array($product->getData('visibility'), array(2, 3, 4)))
+                elseif (! in_array($product->getData('visibility'), $visibleInSite))
                 {
                     $delete = TRUE;
                 }


### PR DESCRIPTION
See comments on code for fix for #273. This uses Magento method calls instead of relying on hard-coded values which could change (or expected behavior of values could change. Using the method calls should have Algolia behave the way the user would expect it to based on native Magento behaviors)