### PR TITLE
Fix for product URLs

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -446,7 +446,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         $customData = array(
             'objectID'          => $product->getId(),
             'name'              => $product->getName(),
-            'url'               => Mage::getBaseUrl() . $product->getRequestPath(),
+            'url'               => $product->getProductUrl(),
             'visibility_search'  => (int) (in_array($visibility, $visibleInSearch)),
             'visibility_catalog' => (int) (in_array($visibility, $visibleInCatalog))
         );


### PR DESCRIPTION
Fix for #277.  NOTE: This should be done as a hotifx release since the current code will make it so that all products generate a 404 from search or categories when using Algolia.