### PR TITLE
Fix missing group_id variable

### DIFF
--- a/design/frontend/template/topsearch.phtml
+++ b/design/frontend/template/topsearch.phtml
@@ -9,6 +9,7 @@
 <?php
 $config = Mage::helper('algoliasearch/config');
 $catalogSearchHelper = $this->helper('catalogsearch');
+$group_id = Mage::getSingleton('customer/session')->getCustomer()->getGroupId();
 $price_key = $config->isCustomerGroupsEnabled(Mage::app()->getStore()->getStoreId()) ? '.group_'.$group_id : '.default';
 
 $title = '';


### PR DESCRIPTION
$group_id is not set anywhere so it throws an error in the template file when customer groups are enabled