### PR TITLE
Add config setting to control logging

### DIFF
--- a/code/Helper/Config.php
+++ b/code/Helper/Config.php
@@ -56,7 +56,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     const AUTOCOMPLETE_SELECTOR                = 'algoliasearch/advanced/autocomplete_selector';
 
     const SHOW_OUT_OF_STOCK                    = 'cataloginventory/options/show_out_of_stock';
-    const LOGGING_ENABLED                      = 'dev/log/active';
+    const LOGGING_ENABLED                      = 'algoliasearch/credentials/debug';
 
     protected $_productTypeMap = array();
 

--- a/code/Helper/Logger.php
+++ b/code/Helper/Logger.php
@@ -53,7 +53,7 @@ class Algolia_Algoliasearch_Helper_Logger extends Mage_Core_Helper_Abstract
 
     public function log($message)
     {
-        if (Mage::getStoreConfigFlag('algoliasearch/credentials/debug')) {
+        if ($this->config->isLoggingEnabled()) {
             Mage::log($message, null, 'algolia.log');
         }
     }

--- a/code/Helper/Logger.php
+++ b/code/Helper/Logger.php
@@ -53,7 +53,9 @@ class Algolia_Algoliasearch_Helper_Logger extends Mage_Core_Helper_Abstract
 
     public function log($message)
     {
-        Mage::log($message, null, 'algolia.log');
+        if (Mage::getStoreConfigFlag('algoliasearch/credentials/debug')) {
+            Mage::log($message, null, 'algolia.log');
+        }
     }
 
     protected function formatTime($begin, $end)

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -140,6 +140,7 @@
                 <application_id></application_id>
                 <search_only_api_key></search_only_api_key>
                 <api_key></api_key>
+                <debug>0</debug>
                 <index_prefix>magento_</index_prefix>
                 <is_popup_enabled>1</is_popup_enabled>
                 <is_instant_enabled>1</is_instant_enabled>

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -85,6 +85,21 @@
                                 ]]>
                             </comment>
                         </enable_frontend>
+                        <debug translate="label comment">
+                            <label>Enable Logging</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>0</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends><enable_backend>1</enable_backend></depends>
+                            <comment>
+                                <![CDATA[
+                                NOTICE: Debug logging generates a significant amount of data and can affect performance of indexing
+                                ]]>
+                            </comment>
+                        </debug>
                         <application_id translate="label">
                             <label>Application ID</label>
                             <frontend_type>text</frontend_type>


### PR DESCRIPTION
Added setting to allow disabling logging (and disable it by default) to avoid creating a large algolia.log file.  This is needed as the main logging setting might be enabled but merchant will not want (or need) this log enabled