### PR TITLE
Correct path to placeholder image

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -579,6 +579,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         $customData['categories'] = $categories_hierarchical;
 
         $customData['categories_without_path'] = $categories;
+        $baseSkinDir = Mage::getBaseDir('skin').DS;
 
         if (false === isset($defaultData['thumbnail_url']))
         {
@@ -593,7 +594,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                 $this->logger->log($e->getMessage());
                 $this->logger->log($e->getTraceAsString());
 
-                $customData['thumbnail_url'] = str_replace(array('https://', 'http://'), '//', Mage::getDesign()->getSkinUrl($thumb->getPlaceholder()));
+                $customData['thumbnail_url'] = str_replace($baseSkinDir, '../skin/', Mage::getDesign()->getSkinUrl($thumb->getPlaceholder()));
             }
         }
 
@@ -610,7 +611,8 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                 $this->logger->log($e->getMessage());
                 $this->logger->log($e->getTraceAsString());
 
-                $customData['image_url'] = str_replace(array('https://', 'http://'), '//', Mage::getDesign()->getSkinUrl($image->getPlaceholder()));
+
+                $customData['image_url'] = str_replace($baseSkinDir, '../skin/', Mage::getDesign()->getSkinUrl($image->getPlaceholder()));
             }
 
             if ($this->isAttributeEnabled($additionalAttributes, 'media_gallery'))


### PR DESCRIPTION
The placeholder is located in skin and in the latest version of the module it's assumed
that all pictures are located in /media
This makes the path to placeholder images wrong.
This fix is hacky, but should work

Feel free to reject this in advantage of a better fix.