### PR TITLE
If a config value for image size is empty, return null

### DIFF
--- a/code/Helper/Config.php
+++ b/code/Helper/Config.php
@@ -123,12 +123,20 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
 
     public function getImageWidth($storeId = null)
     {
-        return Mage::getStoreConfig(self::XML_PATH_IMAGE_WIDTH, $storeId);
+        $imageWidth = Mage::getStoreConfig(self::XML_PATH_IMAGE_WIDTH, $storeId);
+        if(empty($imageWidth)) {
+            return null;
+        }
+        return $imageWidth;
     }
 
     public function getImageHeight($storeId = null)
     {
-        return Mage::getStoreConfig(self::XML_PATH_IMAGE_HEIGHT, $storeId);
+        $imageHeight = Mage::getStoreConfig(self::XML_PATH_IMAGE_HEIGHT, $storeId);
+        if(empty($imageHeight)) {
+            return null;
+        }
+        return $imageHeight;
     }
 
     public function getImageType($storeId = null)


### PR DESCRIPTION
Many stores use square images, and only pass the width to the resize fucntion. The second param is then set to 'null' by default.

To be able to use the same images in Algolia, you'd like to only pass the width there too.

However, in the Magento config, if you're leaving a field empty, the value is an empty string, not null.

So, if you're for example setting the width to 400 and leaving the height value empty in the Algolia config, the values passed is resize(400, '').

This only works if the image is already cached, since magento does a file_exists on the 'would-be-cached' image's filepath, where the filepath is a string, and putting null or '' in a string is practically the same thing.

But - when it is not cached, and Magento tries to resize, it does a strict compare with null, and then tries to resize it with the empty string as a param, and fails, throwing an exception.

This fix basiclly just checks if the value entered is empty, and then returns null instead.