### PR TITLE
Make child and parent skus searchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 ### 1.4.8
 - NEW: allow to have custom product types
-- NEW: make image generation size parameter customizable to be able to save ressources when already in cache
+- NEW: make image generation size parameter customizable to be able to save resources when already in cache
 - UPDATED: remove root category when fetching product categories
 - UPDATED: rewrite image class to be able to log the error when not being able to generate it
 - UPDATED: Handle display price with AND without tax

--- a/code/Helper/Entity/Categoryhelper.php
+++ b/code/Helper/Entity/Categoryhelper.php
@@ -158,11 +158,11 @@ class Algolia_Algoliasearch_Helper_Entity_Categoryhelper extends Algolia_Algolia
         {
             $value = $category->getData($attribute['attribute']);
 
-            $attribute_ressource = $category->getResource()->getAttribute($attribute['attribute']);
+            $attribute_resource = $category->getResource()->getAttribute($attribute['attribute']);
 
-            if ($attribute_ressource)
+            if ($attribute_resource)
             {
-                $value = $attribute_ressource->getFrontend()->getValue($category);
+                $value = $attribute_resource->getFrontend()->getValue($category);
             }
 
             if (isset($data[$attribute['attribute']]))

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -474,6 +474,15 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         }
     }
 
+    protected function getValueOrValueText(Mage_Catalog_Model_Product $product, $name, $resource)
+    {
+        $value_text = $product->getAttributeText($name);
+        if (!$value_text) {
+            $value_text = $resource->getFrontend()->getValue($product);
+        }
+        return $value_text;
+    }
+
     public function getObject(Mage_Catalog_Model_Product $product)
     {
         $type = $this->config->getMappedProductType($product->getTypeId());
@@ -700,7 +709,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
             if ($attribute_resource)
             {
-                $attribute_resource = $attribute_resource->setStoreId($product->getStoreId());
+                $attribute_resource->setStoreId($product->getStoreId());
 
                 if ($value === null)
                 {
@@ -724,12 +733,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
                             if ($value)
                             {
-                                $value_text = $sub_product->getAttributeText($attribute_name);
-
-                                if ($value_text)
-                                    $values[] = $value_text;
-                                else
-                                    $values[] = $attribute_resource->getFrontend()->getValue($sub_product);
+                                $values[] = $this->getValueOrValueText($sub_product, $attribute_name, $attribute_resource);
                             }
                         }
 
@@ -747,15 +751,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                 }
                 else
                 {
-                    $value_text = $product->getAttributeText($attribute_name);
-
-                    if ($value_text)
-                        $value = $value_text;
-                    else
-                    {
-                        $attribute_resource = $attribute_resource->setStoreId($product->getStoreId());
-                        $value = $attribute_resource->getFrontend()->getValue($product);
-                    }
+                    $value = $this->getValueOrValueText($product, $attribute_name, $attribute_resource);
 
                     if ($value)
                     {

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -690,12 +690,13 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
         foreach ($additionalAttributes as $attribute)
         {
-            if (isset($customData[$attribute['attribute']]))
+            $attribute_name = $attribute['attribute'];
+            if (isset($customData[$attribute_name]))
                 continue;
 
-            $value = $product->getData($attribute['attribute']);
+            $value = $product->getData($attribute_name);
 
-            $attribute_resource = $product->getResource()->getAttribute($attribute['attribute']);
+            $attribute_resource = $product->getResource()->getAttribute($attribute_name);
 
             if ($attribute_resource)
             {
@@ -719,11 +720,11 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
                             $all_sub_products_out_of_stock = false;
 
-                            $value = $sub_product->getData($attribute['attribute']);
+                            $value = $sub_product->getData($attribute_name);
 
                             if ($value)
                             {
-                                $value_text = $sub_product->getAttributeText($attribute['attribute']);
+                                $value_text = $sub_product->getAttributeText($attribute_name);
 
                                 if ($value_text)
                                     $values[] = $value_text;
@@ -734,7 +735,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
                         if (is_array($values) && count($values) > 0)
                         {
-                            $customData[$attribute['attribute']] = array_values(array_unique($values));
+                            $customData[$attribute_name] = array_values(array_unique($values));
                         }
 
                         if ($customData['in_stock'] && $all_sub_products_out_of_stock) {
@@ -746,7 +747,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                 }
                 else
                 {
-                    $value_text = $product->getAttributeText($attribute['attribute']);
+                    $value_text = $product->getAttributeText($attribute_name);
 
                     if ($value_text)
                         $value = $value_text;
@@ -758,7 +759,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
                     if ($value)
                     {
-                        $customData[$attribute['attribute']] = $value;
+                        $customData[$attribute_name] = $value;
                     }
                 }
             }

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -695,11 +695,11 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
             $value = $product->getData($attribute['attribute']);
 
-            $attribute_ressource = $product->getResource()->getAttribute($attribute['attribute']);
+            $attribute_resource = $product->getResource()->getAttribute($attribute['attribute']);
 
-            if ($attribute_ressource)
+            if ($attribute_resource)
             {
-                $attribute_ressource = $attribute_ressource->setStoreId($product->getStoreId());
+                $attribute_resource = $attribute_resource->setStoreId($product->getStoreId());
 
                 if ($value === null)
                 {
@@ -728,7 +728,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                                 if ($value_text)
                                     $values[] = $value_text;
                                 else
-                                    $values[] = $attribute_ressource->getFrontend()->getValue($sub_product);
+                                    $values[] = $attribute_resource->getFrontend()->getValue($sub_product);
                             }
                         }
 
@@ -752,8 +752,8 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                         $value = $value_text;
                     else
                     {
-                        $attribute_ressource = $attribute_ressource->setStoreId($product->getStoreId());
-                        $value = $attribute_ressource->getFrontend()->getValue($product);
+                        $attribute_resource = $attribute_resource->setStoreId($product->getStoreId());
+                        $value = $attribute_resource->getFrontend()->getValue($product);
                     }
 
                     if ($value)

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -711,12 +711,16 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
             {
                 $attribute_resource->setStoreId($product->getStoreId());
 
-                if ($value === null)
+                if ($value === null || 'sku' == $attribute_name)
                 {
                     /** Get values as array in children */
                     if ($type == 'configurable' || $type == 'grouped' || $type == 'bundle')
                     {
-                        $values = array();
+                        if ($value === null) {
+                            $values = array();
+                        } else {
+                            $values = array($this->getValueOrValueText($product, $attribute_name, $attribute_resource));
+                        }
 
                         $all_sub_products_out_of_stock = true;
 


### PR DESCRIPTION
Currently Producthelper->getObject only returns attribute values from child
products if the parent product attribute value is null. We would like to be able to
search for the sku of both parent and child products. This patch adds an
exception to getObject to include all the skus in the returned object.
