### PR TITLE
Added cache for popular queries suggestions.

### DIFF
--- a/code/Helper/Entity/Suggestionhelper.php
+++ b/code/Helper/Entity/Suggestionhelper.php
@@ -68,8 +68,8 @@ class Algolia_Algoliasearch_Helper_Entity_Suggestionhelper extends Algolia_Algol
                     $tags = array(
                         Mage_CatalogSearch_Model_Query::CACHE_TAG
                     );
-                    $lifetime = Mage::getStoreConfig('core/cache/lifetime');
-                    Mage::app()->saveCache($cacheContent, $this->_popularQueriesCacheId, $tags, $lifetime);
+
+                    Mage::app()->saveCache($cacheContent, $this->_popularQueriesCacheId, $tags, 604800);
 
                 } catch (Exception $e) {
                     // Exception = no caching

--- a/code/Helper/Entity/Suggestionhelper.php
+++ b/code/Helper/Entity/Suggestionhelper.php
@@ -2,6 +2,9 @@
 
 class Algolia_Algoliasearch_Helper_Entity_Suggestionhelper extends Algolia_Algoliasearch_Helper_Entity_Helper
 {
+    protected $_popularQueries = null;
+    protected $_popularQueriesCacheId = "algoliasearch_popular_queries_cache_tag";
+
     protected function getIndexNameSuffix()
     {
         return '_suggestions';
@@ -32,27 +35,50 @@ class Algolia_Algoliasearch_Helper_Entity_Suggestionhelper extends Algolia_Algol
 
     public function getPopularQueries($storeId)
     {
-        $collection = Mage::getResourceModel('catalogsearch/query_collection');
-        $collection->getSelect()->where('num_results >= '.$this->config->getMinNumberOfResults().' AND popularity >= ' . $this->config->getMinPopularity() .' AND query_text != "__empty__"');
-        $collection->getSelect()->limit(12);
-        $collection->setOrder('popularity', 'DESC');
-        $collection->setOrder('num_results', 'DESC');
-        $collection->setOrder('updated_at', 'ASC');
+        if ($this->_popularQueries == null) {
 
-        if ($storeId) {
-            $collection->getSelect()->where('store_id = ?', (int) $storeId);
+            // load from cache if we can
+            $cachedPopularQueries = Mage::app()->loadCache($this->_popularQueriesCacheId);
+            if ($cachedPopularQueries) {
+                $this->_popularQueries = unserialize($cachedPopularQueries);
+            } else {
+                $collection = Mage::getResourceModel('catalogsearch/query_collection');
+                $collection->getSelect()->where('num_results >= ' . $this->config->getMinNumberOfResults() . ' AND popularity >= ' . $this->config->getMinPopularity() . ' AND query_text != "__empty__"');
+                $collection->getSelect()->limit(12);
+                $collection->setOrder('popularity', 'DESC');
+                $collection->setOrder('num_results', 'DESC');
+                $collection->setOrder('updated_at', 'ASC');
+
+                if ($storeId) {
+                    $collection->getSelect()->where('store_id = ?', (int)$storeId);
+                }
+
+                $collection->load();
+
+                $suggestions = array();
+
+                /** @var $suggestion Mage_Catalog_Model_Category */
+                foreach ($collection as $suggestion)
+                    if (strlen($suggestion['query_text']) >= 3)
+                        $suggestions[] = $suggestion['query_text'];
+
+                $this->_popularQueries = array_slice($suggestions, 0, 9);
+                try { //save to cache
+                    $cacheContent = serialize($this->_popularQueries);
+                    $tags = array(
+                        Mage_CatalogSearch_Model_Query::CACHE_TAG
+                    );
+                    $lifetime = Mage::getStoreConfig('core/cache/lifetime');
+                    Mage::app()->saveCache($cacheContent, $this->_popularQueriesCacheId, $tags, $lifetime);
+
+                } catch (Exception $e) {
+                    // Exception = no caching
+                    Mage::logException($e);
+                }
+            }
         }
 
-        $collection->load();
-
-        $suggestions = array();
-
-        /** @var $suggestion Mage_Catalog_Model_Category */
-        foreach ($collection as $suggestion)
-            if (strlen($suggestion['query_text']) >= 3)
-                $suggestions[] = $suggestion['query_text'];
-
-        return array_slice($suggestions, 0, 9);
+        return $this->_popularQueries;
     }
 
     public function getSuggestionCollectionQuery($storeId)


### PR DESCRIPTION
We found that the getPopularQueries method was quite slow. The query used by this method was taking ~ 0.200ms. Instead of creating an index (ideal solution) for this we decided that a quick win was to save the popular query data to cache.

Let me know your thoughts / improvements.