### PR TITLE
Remove products from Algolia index if disabled

### DIFF
--- a/code/Helper/Config.php
+++ b/code/Helper/Config.php
@@ -85,7 +85,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
 
     /**
      * Returns whether we want to remove disabled products from the Algolia
-     * index.
+     * index during a full re-index.
      *
      * @param mixed $storeId
      * @return bool

--- a/code/Helper/Config.php
+++ b/code/Helper/Config.php
@@ -56,6 +56,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     const MAKE_SEO_REQUEST = 'algoliasearch/advanced/make_seo_request';
     const REMOVE_BRANDING = 'algoliasearch/advanced/remove_branding';
     const AUTOCOMPLETE_SELECTOR = 'algoliasearch/advanced/autocomplete_selector';
+    const REMOVE_DISABLED_PRODUCTS_FROM_INDEX = 'algoliasearch/advanced/remove_disabled_products_from_index';
 
     const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
     const LOGGING_ENABLED = 'algoliasearch/credentials/debug';
@@ -80,6 +81,18 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     public function getAutocompleteSelector($storeId = null)
     {
         return Mage::getStoreConfig(self::AUTOCOMPLETE_SELECTOR, $storeId);
+    }
+
+    /**
+     * Returns whether we want to remove disabled products from the Algolia
+     * index.
+     *
+     * @param mixed $storeId
+     * @return bool
+     */
+    public function removeDisabledProductsFromIndex($storeId = null)
+    {
+        return Mage::getStoreConfigFlag(self::REMOVE_DISABLED_PRODUCTS_FROM_INDEX, $storeId);
     }
 
     public function getNumberOfQueriesSuggestions($storeId = null)

--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -565,7 +565,7 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
      * you want to query. Otherwise, the entire product collection will be
      * queried.
      *
-     * @param string $storeId
+     * @param mixed $storeId
      * @param array $productIds
      * @return array
      */
@@ -577,7 +577,7 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
         $products = Mage::getModel('catalog/product')->getCollection();
         $products
             ->addStoreFilter($storeId)
-            ->addAttributeToFilter('type_id', 'configurable')
+            ->addAttributeToFilter('visibility', array(Mage::getSingleton('catalog/product_visibility')->getVisibleInSiteIds()))
             ->addAttributeToFilter('status', Mage_Catalog_Model_Product_Status::STATUS_DISABLED)
         ;
 

--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -547,14 +547,16 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function removeNonIndexableProducts($storeId, array $productIds = array())
     {
-        $this->logger->start('REMOVE FROM ALGOLIA');
+        if ($this->config->removeDisabledProductsFromIndex($storeId)) {
+            $this->logger->start('REMOVE FROM ALGOLIA');
 
-        $nonIndexableProductIds = $this->getNonIndexableProductIds($storeId, $productIds);
-        if (count($nonIndexableProductIds) > 0) {
-            $this->removeProducts($nonIndexableProductIds, $storeId);
+            $nonIndexableProductIds = $this->getNonIndexableProductIds($storeId, $productIds);
+            if (count($nonIndexableProductIds) > 0) {
+                $this->removeProducts($nonIndexableProductIds, $storeId);
+            }
+
+            $this->logger->stop('REMOVE FROM ALGOLIA');
         }
-
-        $this->logger->stop('REMOVE FROM ALGOLIA');
     }
 
     /**

--- a/code/Model/Observer.php
+++ b/code/Model/Observer.php
@@ -203,12 +203,15 @@ class Algolia_Algoliasearch_Model_Observer
                 }
 
                 $this->helper->rebuildStoreProductIndex($storeId, $productIds);
+                $this->helper->removeNonIndexableProducts($storeId, $productIds);
             }
         } else {
             if (!empty($page) && !empty($pageSize)) {
+                $this->helper->removeNonIndexableProducts($storeId, $productIds);
                 $this->helper->rebuildStoreProductIndexPage($storeId,
                     $this->product_helper->getProductCollectionQuery($storeId, $productIds), $page, $pageSize);
             } else {
+                $this->helper->removeNonIndexableProducts($storeId, $productIds);
                 $this->helper->rebuildStoreProductIndex($storeId, $productIds);
             }
         }

--- a/code/Model/Observer.php
+++ b/code/Model/Observer.php
@@ -206,12 +206,11 @@ class Algolia_Algoliasearch_Model_Observer
                 $this->helper->removeNonIndexableProducts($storeId, $productIds);
             }
         } else {
+            $this->helper->removeNonIndexableProducts($storeId, $productIds);
             if (!empty($page) && !empty($pageSize)) {
-                $this->helper->removeNonIndexableProducts($storeId, $productIds);
                 $this->helper->rebuildStoreProductIndexPage($storeId,
                     $this->product_helper->getProductCollectionQuery($storeId, $productIds), $page, $pageSize);
             } else {
-                $this->helper->removeNonIndexableProducts($storeId, $productIds);
                 $this->helper->rebuildStoreProductIndex($storeId, $productIds);
             }
         }

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -698,6 +698,16 @@
                             <show_in_store>1</show_in_store>
                             <comment>If you don't have the top.search block you can specify the selector of your search input here to use it. Default value is .algolia-search-input</comment>
                         </autocomplete_selector>
+                        <remove_disabled_products_from_index translate="label comment">
+                            <label>Remove disabled products as part of indexing</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>60</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>This feature will allow the indexer to remove disabled products from your Algolia index. This is useful if your products are being disabled without dispatching the catalog_product_save_before event, e.g. a custom solution for importing products.</comment>
+                        </remove_disabled_products_from_index>
                     </fields>
                 </advanced>
             </groups>


### PR DESCRIPTION
This change updates the re-indexing functionality to also remove products that should no longer show up in Algolia.