### PR TITLE
Set product slaves for all sorting indices when customer groups are enabled

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -205,18 +205,15 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
             foreach ($sorting_indices as $values)
             {
-                if ($this->config->isCustomerGroupsEnabled($storeId))
+                if ($this->config->isCustomerGroupsEnabled($storeId) && $values['attribute'] === 'price')
                 {
-                    if ($values['attribute'] === 'price')
+                    foreach ($groups = Mage::getModel('customer/group')->getCollection() as $group)
                     {
-                        foreach ($groups = Mage::getModel('customer/group')->getCollection() as $group)
-                        {
-                            $group_id = (int)$group->getData('customer_group_id');
-
-                            $suffix_index_name = 'group_' . $group_id;
-
-                            $slaves[] = $this->getIndexName($storeId) . '_' .$values['attribute'].'_' . $suffix_index_name . '_' . $values['sort'];
-                        }
+                        $group_id = (int) $group->getData('customer_group_id');
+            
+                        $suffix_index_name = 'group_'.$group_id;
+            
+                        $slaves[] = $this->getIndexName($storeId).'_'.$values['attribute'].'_'.$suffix_index_name.'_'.$values['sort'];
                     }
                 }
                 else


### PR DESCRIPTION
When customer groups are enabled slaves were only being set for price sorts not other sorts that were set such as price, rating etc.