### PR TITLE
Only get attributes for products that are enabled

### DIFF
--- a/code/Helper/Entity/Additionalsectionshelper.php
+++ b/code/Helper/Entity/Additionalsectionshelper.php
@@ -21,6 +21,7 @@ class Algolia_Algoliasearch_Helper_Entity_Additionalsectionshelper extends Algol
         $products = Mage::getResourceModel('catalog/product_collection')
             ->addStoreFilter($storeId)
             ->addAttributeToFilter('visibility', array('in' => Mage::getSingleton('catalog/product_visibility')->getVisibleInSearchIds()))
+            ->addAttributeToFilter('status', array('eq' => Mage_Catalog_Model_Product_Status::STATUS_ENABLED))
             ->addAttributeToFilter($attributeCode, array('notnull' => true))
             ->addAttributeToFilter($attributeCode, array('neq' => ''))
             ->addAttributeToSelect($attributeCode);


### PR DESCRIPTION
When adding additional sections like brands some attributes are shown that are only against products that are disabled so will never have any results in the search