### PR TITLE
Strip magento block directives

### DIFF
--- a/code/Helper/Entity/Helper.php
+++ b/code/Helper/Entity/Helper.php
@@ -70,6 +70,7 @@ abstract class Algolia_Algoliasearch_Helper_Entity_Helper
         $s = trim(preg_replace('/\s+/', ' ', $s));
         $s = preg_replace('/&nbsp;/', ' ', $s);
         $s = preg_replace('!\s+!', ' ', $s);
+        $s = preg_replace('/\{\{[^}]+\}\}/', ' ', $s);
 
         return trim(strip_tags($s));
     }


### PR DESCRIPTION
Remove magento specific syntax from indexed pages. When searching for "black..." in the autocomplete dropdown it was showing {{block type="core/template" template="page/html... below the page's name.