### PR TITLE
CMS content: template directives

### DIFF
--- a/code/Helper/Config.php
+++ b/code/Helper/Config.php
@@ -28,6 +28,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     const EXCLUDED_PAGES                       = 'algoliasearch/autocomplete/excluded_pages';
     const MIN_POPULARITY                       = 'algoliasearch/autocomplete/min_popularity';
     const MIN_NUMBER_OF_RESULTS                = 'algoliasearch/autocomplete/min_number_of_results';
+    const RENDER_TEMPLATE_DIRECTIVES           = 'algoliasearch/autocomplete/render_template_directives';
 
     const NUMBER_OF_PRODUCT_RESULTS            = 'algoliasearch/products/number_product_results';
     const PRODUCT_ATTRIBUTES                   = 'algoliasearch/products/product_additional_attributes';
@@ -269,6 +270,11 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
             return $attrs;
 
         return array();
+    }
+
+    public function getRenderTemplateDirectives($storeId = NULL)
+    {
+        return Mage::getStoreConfigFlag(self::RENDER_TEMPLATE_DIRECTIVES, $storeId);
     }
 
     public function getSortingIndices($storeId = NULL)

--- a/code/Helper/Entity/Pagehelper.php
+++ b/code/Helper/Entity/Pagehelper.php
@@ -45,11 +45,15 @@ class Algolia_Algoliasearch_Helper_Entity_Pagehelper extends Algolia_Algoliasear
             if (! $page->getId())
                 continue;
 
-            $tmplProc = Mage::helper('cms')->getPageTemplateProcessor();
+            $content = $page->getContent();
+            if ($this->config->getRenderTemplateDirectives()) {
+                $tmplProc = Mage::helper('cms')->getPageTemplateProcessor();
+                $content = $tmplProc->filter($content);
+            }
 
             $page_obj['objectID'] = $page->getId();
             $page_obj['url'] = Mage::helper('cms/page')->getPageUrl($page->getId());
-            $page_obj['content'] = $this->strip($tmplProc->filter($page->getContent()));
+            $page_obj['content'] = $this->strip($content);
 
             $pages[] = $page_obj;
         }

--- a/code/Helper/Entity/Pagehelper.php
+++ b/code/Helper/Entity/Pagehelper.php
@@ -45,10 +45,11 @@ class Algolia_Algoliasearch_Helper_Entity_Pagehelper extends Algolia_Algoliasear
             if (! $page->getId())
                 continue;
 
-            $page_obj['objectID'] = $page->getId();
+            $tmplProc = Mage::helper('cms')->getPageTemplateProcessor();
 
+            $page_obj['objectID'] = $page->getId();
             $page_obj['url'] = Mage::helper('cms/page')->getPageUrl($page->getId());
-            $page_obj['content'] = $this->strip($page->getContent());
+            $page_obj['content'] = $this->strip($tmplProc->filter($page->getContent()));
 
             $pages[] = $page_obj;
         }

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -168,6 +168,7 @@
                 <sections>a:1:{s:18:"_1450089283397_397";a:3:{s:4:"name";s:5:"pages";s:5:"label";s:5:"Pages";s:11:"hitsPerPage";s:1:"2";}}</sections>
                 <min_popularity>1000</min_popularity>
                 <min_number_of_results>2</min_number_of_results>
+                <render_template_directives>1</render_template_directives>
             </autocomplete>
             <categories>
                 <number_category_suggestions>5</number_category_suggestions>
@@ -201,4 +202,4 @@
             </product_map>
         </algoliasearch>
     </default>
-</config> 
+</config>

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -258,8 +258,7 @@
                             <show_in_store>1</show_in_store>
                             <comment>
                                 <![CDATA[
-                                Configure here the pages you don't want to search in.<br><br>
-                                <span style="font-size: 20px; color: #D83900">&#9888;</span> Do not forget to trigger the Algolia Search indexers whenever you modify those settings.
+                                Configure here the pages you don't want to search in.
                                 ]]>
                             </comment>
                         </excluded_pages>
@@ -273,7 +272,8 @@
                             <show_in_store>1</show_in_store>
                             <comment>
                                 <![CDATA[
-                                For CMS pages, template directives (e.g. <code>{{{{block type="core/template" ...}}</code>) will be processed by default. Set this to "No" if you don't want to have template content indexed.
+                                For CMS pages, template directives (e.g. <code>{{block type="core/template" ...}}</code>) will be processed by default. Set this to "No" if you don't want to have template content indexed.<br><br>
+                                <span style="font-size: 20px; color: #D83900">&#9888;</span> Do not forget to trigger the Algolia Search indexers whenever you modify those settings.
                                 ]]>
                             </comment>
                         </render_template_directives>

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -32,7 +32,7 @@
                     <sort_order>10</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
-                    <show_in_store>1</show_in_store>  
+                    <show_in_store>1</show_in_store>
                     <expanded>1</expanded>
                     <comment>
                      <![CDATA[
@@ -263,6 +263,20 @@
                                 ]]>
                             </comment>
                         </excluded_pages>
+                        <render_template_directives translate="label comment">
+                            <label>Render template directives</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>
+                                <![CDATA[
+                                For CMS pages, template directives (e.g. <code>{{{{block type="core/template" ...}}</code>) will be processed by default. Set this to "No" if you don't want to have template content indexed.
+                                ]]>
+                            </comment>
+                        </render_template_directives>
                     </fields>
                 </autocomplete>
                 <instant>


### PR DESCRIPTION
# Changed
  - When indexing CMS pages, this module will render template directives by default instead of simply stripping them out.

# Added
  - Adds a configuration option to the Admin Panel which allows the user to change this behavior, if desired.

# Screenshots

Admin Panel:

![template-directives](https://cloud.githubusercontent.com/assets/3905798/14888211/28e60836-0d27-11e6-9a21-75b2743ce968.png)