### PR TITLE
Save index settings on full products rebuild

### DIFF
--- a/code/Model/Resource/Engine.php
+++ b/code/Model/Resource/Engine.php
@@ -168,6 +168,8 @@ class Algolia_Algoliasearch_Model_Resource_Engine extends Mage_CatalogSearch_Mod
 
     public function rebuildProducts()
     {
+        $this->saveSettings();
+        
         foreach (Mage::app()->getStores() as $store)
         {
             if ($this->config->isEnabledBackEnd($store->getId()) === false)


### PR DESCRIPTION
It should fix the bug when you build dev container for the first time and index settings are not set.

_Not sure if we want to call saveSettings everytime when rebuilding products, but I don't know where to put it besides creating a new indexer._