### PR TITLE
Index SKUs again

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -816,7 +816,9 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                             $customData['in_stock'] = 0;
                         }
                     }
-                } else {
+                }
+
+                if ($value !== null) {
                     $value = $this->getValueOrValueText($product, $attribute_name, $attribute_resource);
 
                     if ($value) {


### PR DESCRIPTION
This has happened as a result of a trivial logic error. The commit might not be the most clear way to fix the logic error, feel free to restructure the `if ($value === null || 'sku' == $attribute_name)`, it's complementary `else` and the `if ($type == 'configurable' || ...` otherwise if you can think of a better way.

-------------------------------------------------

6bc7085 wishes to be able to index SKUs for both child products
themselves and for their parent products at the same time. The commit
had the effect of indexing child SKUs for parent products, but child
products themselves did not get indexed any more. This commit enables
indexing of child or standalone product SKUs again.