### PR TITLE
Fix already set elements indexing

### DIFF
--- a/code/Helper/Entity/Additionalsectionshelper.php
+++ b/code/Helper/Entity/Additionalsectionshelper.php
@@ -52,7 +52,6 @@ class Algolia_Algoliasearch_Helper_Entity_Additionalsectionshelper extends Algol
         }
 
         $values = array_map(function ($value) use ($section, $storeId) {
-
             $record = [
                 'objectID' => $value,
                 'value'    => $value,

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -812,17 +812,17 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                         $customData[$attribute_name] = array_values(array_unique($values));
                     }
 
+                    // Set main product out of stock if all
+                    // sub-products are out of stock.
                     if ($customData['in_stock'] && $all_sub_products_out_of_stock) {
-                        // Set main product out of stock if all
-                        // sub-products is out of stock.
                         $customData['in_stock'] = 0;
                     }
-                } else {
+                } elseif ($value === null) {
                     $value = $this->getValueOrValueText($product, $attribute_name, $attribute_resource);
+                }
 
-                    if ($value) {
-                        $customData[$attribute_name] = $value;
-                    }
+                if ($value && !isset($customData[$attribute_name])) {
+                    $customData[$attribute_name] = $value;
                 }
             }
         }


### PR DESCRIPTION
When I tried to index attribute `category_ids` it failed because it tried to fetch textual value of attribute. But the attribute was already set. There was probably logical error in condition.
Could you please review as I'm not sure it's not harmful. I tested it a bit and seems to work OK.