### PR TITLE
Simpler products removing

### DIFF
--- a/code/Helper/Config.php
+++ b/code/Helper/Config.php
@@ -56,7 +56,6 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     const MAKE_SEO_REQUEST = 'algoliasearch/advanced/make_seo_request';
     const REMOVE_BRANDING = 'algoliasearch/advanced/remove_branding';
     const AUTOCOMPLETE_SELECTOR = 'algoliasearch/advanced/autocomplete_selector';
-    const REMOVE_DISABLED_PRODUCTS_FROM_INDEX = 'algoliasearch/advanced/remove_disabled_products_from_index';
     const INDEX_PRODUCT_ON_CATEGORY_PRODUCTS_UPDATE = 'algoliasearch/advanced/index_product_on_category_products_update';
 
     const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
@@ -82,18 +81,6 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     public function getAutocompleteSelector($storeId = null)
     {
         return Mage::getStoreConfig(self::AUTOCOMPLETE_SELECTOR, $storeId);
-    }
-
-    /**
-     * Returns whether we want to remove disabled products from the Algolia
-     * index during a full re-index.
-     *
-     * @param mixed $storeId
-     * @return bool
-     */
-    public function removeDisabledProductsFromIndex($storeId = null)
-    {
-        return Mage::getStoreConfigFlag(self::REMOVE_DISABLED_PRODUCTS_FROM_INDEX, $storeId);
     }
 
     public function indexProductOnCategoryProductsUpdate($storeId = null)

--- a/code/Helper/Entity/Categoryhelper.php
+++ b/code/Helper/Entity/Categoryhelper.php
@@ -123,7 +123,9 @@ class Algolia_Algoliasearch_Helper_Entity_Categoryhelper extends Algolia_Algolia
         /** @var Algolia_Algoliasearch_Helper_Entity_Producthelper $productHelper */
         $productHelper = Mage::helper('algoliasearch/entity_producthelper');
 
-        $productCollection = clone $productHelper->getProductCollectionQuery($storeId, null, true, true);
+        $collection = $productHelper->getProductCollectionQuery($storeId, null, true, true);
+
+        $productCollection = clone $collection;
         $productCollection = $productCollection->addCategoryFilter($category);
 
         $category->setProductCount($productCollection->getSize());

--- a/code/Helper/Entity/Helper.php
+++ b/code/Helper/Entity/Helper.php
@@ -28,9 +28,15 @@ abstract class Algolia_Algoliasearch_Helper_Entity_Helper
         return (string) $this->config->getIndexPrefix($storeId).Mage::app()->getStore($storeId)->getCode();
     }
 
-    public function getIndexName($storeId = null)
+    public function getIndexName($storeId = null, $getTmpIndexName = false)
     {
-        return (string) $this->getBaseIndexName($storeId).$this->getIndexNameSuffix();
+        $indexName = (string) $this->getBaseIndexName($storeId).$this->getIndexNameSuffix();
+
+        if ($getTmpIndexName === true) {
+            $indexName .= '_tmp';
+        }
+
+        return $indexName;
     }
 
     protected function try_cast($value)

--- a/code/Model/Indexer/Abstract.php
+++ b/code/Model/Indexer/Abstract.php
@@ -61,7 +61,6 @@ abstract class Algolia_Algoliasearch_Model_Indexer_Abstract extends Mage_Index_M
         }
 
         if (!empty($productIds)) {
-            $this->engine->removeProducts(null, $productIds);
             $this->engine->rebuildProductIndex(null, $productIds);
         }
     }

--- a/code/Model/Indexer/Algolia.php
+++ b/code/Model/Indexer/Algolia.php
@@ -111,7 +111,6 @@ class Algolia_Algoliasearch_Model_Indexer_Algolia extends Algolia_Algoliasearch_
             try {
                 // In case of wrong credentials or overquota or block account. To avoid checkout process to fail
 
-                $event->addNewData('catalogsearch_delete_product_id', $product->getId());
                 $event->addNewData('catalogsearch_update_category_id', $product->getCategoryIds());
             } catch (\Exception $e) {
                 $this->logger->log('Error while trying to update stock');
@@ -127,6 +126,7 @@ class Algolia_Algoliasearch_Model_Indexer_Algolia extends Algolia_Algoliasearch_
             case Mage_Index_Model_Event::TYPE_SAVE:
                 /** @var $product Mage_Catalog_Model_Product */
                 $product = $event->getDataObject();
+
                 $event->addNewData('catalogsearch_update_product_id', $product->getId());
                 $event->addNewData('catalogsearch_update_category_id', $product->getCategoryIds());
 
@@ -143,9 +143,9 @@ class Algolia_Algoliasearch_Model_Indexer_Algolia extends Algolia_Algoliasearch_
                 break;
 
             case Mage_Index_Model_Event::TYPE_DELETE:
-
                 /** @var $product Mage_Catalog_Model_Product */
                 $product = $event->getDataObject();
+
                 $event->addNewData('catalogsearch_update_product_id', $product->getId());
                 $event->addNewData('catalogsearch_update_category_id', $product->getCategoryIds());
                 break;
@@ -155,7 +155,6 @@ class Algolia_Algoliasearch_Model_Indexer_Algolia extends Algolia_Algoliasearch_
                 $actionObject = $event->getDataObject();
 
                 $event->addNewData('catalogsearch_update_product_id', $actionObject->getProductIds());
-
                 break;
         }
 

--- a/code/Model/Queue.php
+++ b/code/Model/Queue.php
@@ -115,17 +115,23 @@ class Algolia_Algoliasearch_Model_Queue
 
                 if ($this->mergeable($current_job, $next_job)) {
                     if (isset($current_job['data']['product_ids'])) {
-                        $current_job['data']['product_ids'] = array_merge($current_job['data']['product_ids'],
-                            $next_job['data']['product_ids']);
+                        $current_job['data']['product_ids'] = array_merge($current_job['data']['product_ids'], $next_job['data']['product_ids']);
                     } else {
-                        $current_job['data']['category_ids'] = array_merge($current_job['data']['category_ids'],
-                            $next_job['data']['category_ids']);
+                        $current_job['data']['category_ids'] = array_merge($current_job['data']['category_ids'], $next_job['data']['category_ids']);
                     }
 
                     continue;
                 }
             } else {
                 $next_job = null;
+            }
+
+            if (isset($current_job['data']['product_ids'])) {
+                $current_job['data']['product_ids'] = array_unique($current_job['data']['product_ids']);
+            }
+
+            if (isset($current_job['data']['category_ids'])) {
+                $current_job['data']['category_ids'] = array_unique($current_job['data']['category_ids']);
             }
 
             $jobs[] = $current_job;

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -698,16 +698,6 @@
                             <show_in_store>1</show_in_store>
                             <comment>If you don't have the top.search block you can specify the selector of your search input here to use it. Default value is .algolia-search-input</comment>
                         </autocomplete_selector>
-                        <remove_disabled_products_from_index translate="label comment">
-                            <label>Remove disabled products as part of indexing</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>60</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <comment>This feature will allow the indexer to remove disabled products from your Algolia index. This is useful if your products are being disabled without dispatching the catalog_product_save_before event, e.g. a custom solution for importing products.</comment>
-                        </remove_disabled_products_from_index>
                         <index_product_on_category_products_update translate="label comment">
                             <label>Update product on category products update</label>
                             <frontend_type>select</frontend_type>


### PR DESCRIPTION
Implements #424 

- works everytime
- no specific configuration needed
- keeps indices in consistent state
- simplifies code
- makes queue more effective, because there is no need to add `removeProducts` to queue table. So only merged `rebuildProducts` tasks are processed. 