### PR TITLE
Fix showing instant search bars on products' details

### DIFF
--- a/design/frontend/template/instantsearch.phtml
+++ b/design/frontend/template/instantsearch.phtml
@@ -566,24 +566,12 @@ if ($config->isInstantEnabled() && $config->replaceCategories() && Mage::app()->
                 })
             );
 
-            /** Initialise searching **/
-            if (algoliaConfig.isSearchPage) {
-                startInstantSearch();
-            }
-            else {
-                (function () {
-                    var isStarted = false;
-
-                    $(instant_selector).one('focus', (function () {
-                        if (!isStarted) {
-                            startInstantSearch();
-                        }
-                        isStarted = true;
-                    }));
-                })();
-            }
-
+            var isStarted = false;
             function startInstantSearch() {
+                if(isStarted == true) {
+                    return;
+                }
+
                 search.start();
 
                 handleInputCrossInstant($(instant_selector));
@@ -600,7 +588,12 @@ if ($config->isInstantEnabled() && $config->replaceCategories() && Mage::app()->
                 $(document).on('click', '.ais-hierarchical-menu--link, .ais-refinement-list--checkbox', function () {
                     focusInstantSearchBar(search, instant_search_bar);
                 });
+
+                isStarted = true;
             }
+
+            /** Initialise searching **/
+            startInstantSearch();
         });
     });
 


### PR DESCRIPTION
@maxiloc It was caused because instant search was no started. I strart it everytime now and works. I tested all the combinationas turned on/off autocomplete / instant search and it works OK. Did I miss some use case or can we leave it like that?