### PR TITLE
Prices being indexed excl.tax instead of incl.tax in some tax setups

### DIFF
--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -13,6 +13,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         'small_image',
         'thumbnail',
         'msrp_enabled', // NEEDED to handle msrp behavior
+        'tax_class_id', // Needed for tax calculation
     ];
 
     protected function getIndexNameSuffix()


### PR DESCRIPTION
In some setups, like when catalog prices are maintained excl. tax and displayed in the store with tax, the price still get indexed without tax, even when $with_tax returns true here (Helper/Entity/Producthelper.php, line 315):

$price = (double) Mage::helper('tax')->getPrice($product, $product->getPrice(), $with_tax, ...

This seems to be due to that the tax helper's getPrice function tries to get the tax percant / tax class from $product, but $product doesn't include that, returns NULL, and no tax is added.

This fixes that by including the tax class id in the product collection.