### PR TITLE
Encode attribute values

### DIFF
--- a/js/algoliasearch/internals/frontend/common.js
+++ b/js/algoliasearch/internals/frontend/common.js
@@ -194,7 +194,7 @@ document.addEventListener("DOMContentLoaded", function (e) {
 					name: i,
 					templates: {
 						suggestion: function (hit) {
-							hit.url = algoliaConfig.baseUrl + '/catalogsearch/result/?q=' + hit.value + '&refinement_key=' + section.name;
+							hit.url = algoliaConfig.baseUrl + '/catalogsearch/result/?q=' + encodeURIComponent(hit.value) + '&refinement_key=' + section.name;
 							return algoliaConfig.autocomplete.templates.additionnalSection.render(hit);
 						}
 					}


### PR DESCRIPTION
We had this problem when manufacturer attribute contained "+" or "&" characters, in this case in suggestion list the url is not escaped leading to special symbols being dropped and no results are returned, specially with "&" only symbols before are used for search. Yet after this change the selected filters have the ampersand double escaped, but at least there are results for the search