### PR TITLE
Removed the No or N/A values from being indexed

### DIFF
--- a/code/Block/System/Config/Form/Field/ProductAdditionalAttributes.php
+++ b/code/Block/System/Config/Form/Field/ProductAdditionalAttributes.php
@@ -51,6 +51,14 @@ class Algolia_Algoliasearch_Block_System_Config_Form_Field_ProductAdditionalAttr
                     ],
                     'rowMethod' => 'getOrder',
                 ],
+                'index_no_value' => [
+                    'label'   => 'Index the default empty attribute value (No or N/A)',
+                    'options' => [
+                        '1'     => 'Yes',
+                        '0'     => 'No',
+                    ],
+                    'rowMethod' => 'getIndexNoValue',
+                ],
             ],
             'buttonLabel' => 'Add Attribute',
             'addAfter'    => false,

--- a/code/Helper/Config.php
+++ b/code/Helper/Config.php
@@ -414,9 +414,10 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
             }
 
             $attrs[] = [
-                'attribute'   => $facet['attribute'],
-                'searchable'  => '0',
-                'retrievable' => '1',
+                'attribute'         => $facet['attribute'],
+                'searchable'        => '0',
+                'retrievable'       => '1',
+                'index_no_value'    => '1'
             ];
         }
 

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -584,7 +584,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         }
     }
 
-    protected function getValueOrValueText(Mage_Catalog_Model_Product $product, $name, Mage_Catalog_Model_Resource_Eav_Attribute $resource, boolean $index_no_value)
+    protected function getValueOrValueText(Mage_Catalog_Model_Product $product, $name, Mage_Catalog_Model_Resource_Eav_Attribute $resource, $index_no_value)
     {
         $value_text = $product->getAttributeText($name);
         if (!$value_text) {

--- a/code/Helper/Entity/Producthelper.php
+++ b/code/Helper/Entity/Producthelper.php
@@ -591,7 +591,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
             $value_text = $resource->getFrontend()->getValue($product);
         }
 
-        return $value_text;
+        return $value_text == Mage::helper('catalog')->__('No') ? null : $value_text;
     }
 
     public function getObject(Mage_Catalog_Model_Product $product)


### PR DESCRIPTION
If a product attribute is empty, Magento is returning N/A or No. By excluding these values we get cleaner facets instead of a lot of values in a facet with just one option: N/A.