### PR TITLE
Hits widget: Use allItems template not item

### DIFF
--- a/app/design/frontend/base/default/template/algoliasearch/instantsearch/hit.phtml
+++ b/app/design/frontend/base/default/template/algoliasearch/instantsearch/hit.phtml
@@ -14,60 +14,62 @@ $price_key = $config->isCustomerGroupsEnabled(Mage::app()->getStore()->getStoreI
 
 <!-- Product hit template -->
 <script type="text/template" id="instant-hit-template">
-    <div class="col-md-4 col-sm-6">
-        <div class="result-wrapper">
-            <a href="{{url}}" class="result">
-                <div class="result-content">
-                    <div class="result-thumbnail">
-                        {{#image_url}}<img src="{{{ image_url }}}"/>{{/image_url}}
-                        {{^image_url}}<span class="no-image"></span>{{/image_url}}
-                    </div>
-                    <div class="result-sub-content">
-                        <h3 class="result-title text-ellipsis">
-                            {{{ _highlightResult.name.value }}}
-                        </h3>
-                        <div class="ratings">
-                            <div class="ratings-wrapper">
-                                <div class="ratings-sub-content">
-                                    <div class="rating-box">
-                                        <div class="rating" style="width:{{rating_summary}}%" width="148" height="148"></div>
+    {{#hits}}
+        <div class="col-md-4 col-sm-6">
+            <div class="result-wrapper">
+                <a href="{{url}}" class="result">
+                    <div class="result-content">
+                        <div class="result-thumbnail">
+                            {{#image_url}}<img src="{{{ image_url }}}"/>{{/image_url}}
+                            {{^image_url}}<span class="no-image"></span>{{/image_url}}
+                        </div>
+                        <div class="result-sub-content">
+                            <h3 class="result-title text-ellipsis">
+                                {{{ _highlightResult.name.value }}}
+                            </h3>
+                            <div class="ratings">
+                                <div class="ratings-wrapper">
+                                    <div class="ratings-sub-content">
+                                        <div class="rating-box">
+                                            <div class="rating" style="width:{{rating_summary}}%" width="148" height="148"></div>
+                                        </div>
                                     </div>
-                                </div>
-                                <div class="price">
-                                    <div class="price-wrapper">
-                                        <div>
-                                            <span
-                                                class="after_special {{#price<?php echo $price_key; ?>_original_formated}}promotion{{/price<?php echo $price_key; ?>_original_formated}}">
-                                                {{price<?php echo $price_key; ?>_formated}}
-                                            </span>
-
-                                            {{#price<?php echo $price_key; ?>_original_formated}}
-                                                <span class="before_special">
-                                                    {{price<?php echo $price_key; ?>_original_formated}}
+                                    <div class="price">
+                                        <div class="price-wrapper">
+                                            <div>
+                                                <span
+                                                    class="after_special {{#price<?php echo $price_key; ?>_original_formated}}promotion{{/price<?php echo $price_key; ?>_original_formated}}">
+                                                    {{price<?php echo $price_key; ?>_formated}}
                                                 </span>
-                                            {{/price<?php echo $price_key; ?>_original_formated}}
+
+                                                {{#price<?php echo $price_key; ?>_original_formated}}
+                                                    <span class="before_special">
+                                                        {{price<?php echo $price_key; ?>_original_formated}}
+                                                    </span>
+                                                {{/price<?php echo $price_key; ?>_original_formated}}
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                        <div class="result-description text-ellipsis">{{{ _highlightResult.description.value }}}</div>
+                            <div class="result-description text-ellipsis">{{{ _highlightResult.description.value }}}</div>
 
-                        {{#isAddToCartEnabled}}
-                            {{#in_stock}}
-                                <form action="<?php echo Mage::getBaseUrl(); ?>/checkout/cart/add/product/{{objectID}}"
-                                      method="post">
-                                    <input type="hidden" name="form_key"
-                                           value="<?php echo Mage::getSingleton('core/session')->getFormKey(); ?>"/>
-                                    <input type="hidden" name="qty" value="1">
-                                    <button type="submit"><?php echo $this->__('Add to Cart'); ?></button>
-                                </form>
-                            {{/in_stock}}
-                        {{/isAddToCartEnabled}}
+                            {{#isAddToCartEnabled}}
+                                {{#in_stock}}
+                                    <form action="<?php echo Mage::getBaseUrl(); ?>/checkout/cart/add/product/{{objectID}}"
+                                          method="post">
+                                        <input type="hidden" name="form_key"
+                                               value="<?php echo Mage::getSingleton('core/session')->getFormKey(); ?>"/>
+                                        <input type="hidden" name="qty" value="1">
+                                        <button type="submit"><?php echo $this->__('Add to Cart'); ?></button>
+                                    </form>
+                                {{/in_stock}}
+                            {{/isAddToCartEnabled}}
+                        </div>
                     </div>
-                </div>
-                <div class="clearfix"></div>
-            </a>
+                    <div class="clearfix"></div>
+                </a>
+            </div>
         </div>
-    </div>
+    {{/hits}}
 </script>

--- a/js/algoliasearch/instantsearch.js
+++ b/js/algoliasearch/instantsearch.js
@@ -156,16 +156,18 @@ document.addEventListener("DOMContentLoaded", function (event) {
 			algoliaBundle.instantsearch.widgets.hits({
 				container: '#instant-search-results-container',
 				templates: {
-					item: $('#instant-hit-template').html()
+					allItems: $('#instant-hit-template').html()
 				},
 				transformData: {
-					item: function (hit) {
-						hit = transformHit(hit, algoliaConfig.priceKey);
-						hit.isAddToCartEnabled = algoliaConfig.instant.isAddToCartEnabled;
+					allItems: function (results) {
+						for (var i = 0; i < results.hits.length; i++) {
+							results.hits[i] = transformHit(results.hits[i], algoliaConfig.priceKey);
+							results.hits[i].isAddToCartEnabled = algoliaConfig.instant.isAddToCartEnabled;
+							
+							results.hits[i].algoliaConfig = window.algoliaConfig;
+						}
 						
-						hit.algoliaConfig = window.algoliaConfig;
-						
-						return hit;
+						return results;
 					}
 				},
 				hitsPerPage: algoliaConfig.hitsPerPage


### PR DESCRIPTION
Following on from issue #322 this patch updates the hit widget to use the
allItems template. It updates hit.phtml with the {{hits}} tags so that it
continues to work as before.

The diff on hit.phtml is a lot more readable if you diff with -b