### PR TITLE
Change algolia queue data column type to TEXT

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/sql/algoliasearch_setup/mysql4-upgrade-1.6.0-1.7.1.php
+++ b/app/code/community/Algolia/Algoliasearch/sql/algoliasearch_setup/mysql4-upgrade-1.6.0-1.7.1.php
@@ -1,0 +1,11 @@
+<?php
+
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+$tableName = Mage::getSingleton('core/resource')->getTableName('algoliasearch/queue');
+
+$installer->run('ALTER TABLE ' . $tableName . ' MODIFY data TEXT NOT NULL');
+
+$installer->endSetup();


### PR DESCRIPTION
Hello,

The `data` column of the queue table (`algoliasearch_queue`) is a `VARCHAR(5000)` so if you reindex more than 1000 products for example, it will cut the json and make it invalid.

This PR updates the type to `TEXT`.