### PR TITLE
PHP 5.3 compatibility fix

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Block/System/Config/Form/Field/ProductAdditionalAttributes.php
+++ b/app/code/community/Algolia/Algoliasearch/Block/System/Config/Form/Field/ProductAdditionalAttributes.php
@@ -51,14 +51,14 @@ class Algolia_Algoliasearch_Block_System_Config_Form_Field_ProductAdditionalAttr
                     ),
                     'rowMethod' => 'getOrder',
                 ),
-                'index_no_value' => [
+                'index_no_value' => array(
                     'label'   => 'Index empty value',
-                    'options' => [
+                    'options' => array(
                         '1'     => 'Yes',
                         '0'     => 'No',
-                    ],
+                    ),
                     'rowMethod' => 'getIndexNoValue',
-                ],
+                ),
             ),
             'buttonLabel' => 'Add Attribute',
             'addAfter'    => false,


### PR DESCRIPTION
This one was missed when restoring PHP 5.3 compatibility (causes a fatal error in the Magento configuration area)