### PR TITLE
Fix to show correct bundle product prices

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
@@ -14,6 +14,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         'thumbnail',
         'msrp_enabled', // NEEDED to handle msrp behavior
         'tax_class_id', // Needed for tax calculation
+        'price_type', // Needed for bundle prices
     );
 
     private $excludedAttrsFromBundledProducts = array(


### PR DESCRIPTION
When a bundle product does have a special price the old price isn't shown. This is because the `price_type` attribute isn't selected, see: https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Bundle/Model/Product/Price.php#L69-L76