### PR TITLE
Set hardcoded searchable attributes as unordered.

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Entity/Additionalsectionshelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Entity/Additionalsectionshelper.php
@@ -10,7 +10,7 @@ class Algolia_Algoliasearch_Helper_Entity_Additionalsectionshelper extends Algol
     public function getIndexSettings($storeId)
     {
         return array(
-            'attributesToIndex' => array('value'),
+            'attributesToIndex' => array('unordered(value)'),
         );
     }
 

--- a/app/code/community/Algolia/Algoliasearch/Helper/Entity/Pagehelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Entity/Pagehelper.php
@@ -10,7 +10,7 @@ class Algolia_Algoliasearch_Helper_Entity_Pagehelper extends Algolia_Algoliasear
     public function getIndexSettings($storeId)
     {
         return array(
-            'attributesToIndex'   => array('slug', 'name', 'unordered(content)'),
+            'attributesToIndex'   => array('unordered(slug)', 'unordered(name)', 'unordered(content)'),
             'attributesToSnippet' => array('content:7'),
         );
     }

--- a/app/code/community/Algolia/Algoliasearch/Helper/Entity/Suggestionhelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Entity/Suggestionhelper.php
@@ -13,7 +13,7 @@ class Algolia_Algoliasearch_Helper_Entity_Suggestionhelper extends Algolia_Algol
     public function getIndexSettings($storeId)
     {
         return array(
-            'attributesToIndex'      => array('query'),
+            'attributesToIndex'      => array('unordered(query)'),
             'customRanking'          => array('desc(popularity)', 'desc(number_of_results)', 'asc(date)'),
             'typoTolerance'          => false,
             'attributesToRetrieve'   => array('query'),


### PR DESCRIPTION
In general it's better for relevancy.