### PR TITLE
Fix uncaught error in Indexer_Abstract

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Model/Indexer/Abstract.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Indexer/Abstract.php
@@ -87,6 +87,14 @@ abstract class Algolia_Algoliasearch_Model_Indexer_Abstract extends Mage_Index_M
         /** @var Mage_Catalog_Model_Product $product */
         $product = Mage::getModel('catalog/product')->loadByAttribute('entity_id', $productId);
 
+        if ($product === false) {
+            return false;
+        }
+
+        if (!$product->getId()) {
+            return false;
+        }
+
         return $product->isComposite();
     }
 }


### PR DESCRIPTION
# Steps to reproduce the problem

1. Install a fresh copy of Magento v1.9.3.0 with sample data
2. Install and configure the Algolia search extension `v1.7.1`, indexing all products
3. In the admin panel, under Catalog > Manage Products, click the checkbox next to at least one product.
4. From the "Actions" dropdown, select "Delete" and then press the "Submit" button.

# What did I expect to happen?

I expected the products to be deleted without any issue.

# What happened instead?

The admin panel crashed with the following error message:

```
Fatal error: Uncaught Error: Call to a member function isComposite() on boolean in algolia/algoliasearch-magento/app/code/community/Algolia/Algoliasearch/Model/Indexer/Abstract.php:90
```