### PR TITLE
Loading stockItems when required within Algolia_Algoliasearch_Helper_Entity_Producthelper::getObject

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
@@ -843,6 +843,11 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
         if (false === isset($defaultData['in_stock'])) {
             $stockItem = $product->getStockItem();
 
+            // getStockItem isn't always available
+            if (is_object($stockItem) === false) {
+                $stockItem = Mage::getModel('cataloginventory/stock_item')->loadByProduct($product);
+            }
+
             $customData['in_stock'] = (int) $stockItem->getIsInStock();
         }
 
@@ -902,7 +907,14 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
                     if ($type !== 'bundle' || in_array($attribute_name, $this->excludedAttrsFromBundledProducts, true) === false) {
                         foreach ($sub_products as $sub_product) {
-                            $isInStock = (int)$sub_product->getStockItem()->getIsInStock();
+
+                            $stockItem = $sub_product->getStockItem();
+
+                            // getStockItem isn't always available
+                            if (is_object($stockItem) === false) {
+                                $stockItem = Mage::getModel('cataloginventory/stock_item')->loadByProduct($sub_product);
+                            }
+                            $isInStock = (int)$stockItem->getIsInStock();
 
                             if ($isInStock == false && $this->config->indexOutOfStockOptions($product->getStoreId()) == false) {
                                 continue;

--- a/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
@@ -907,7 +907,6 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
                     if ($type !== 'bundle' || in_array($attribute_name, $this->excludedAttrsFromBundledProducts, true) === false) {
                         foreach ($sub_products as $sub_product) {
-
                             $stockItem = $sub_product->getStockItem();
 
                             // getStockItem isn't always available


### PR DESCRIPTION
We have an external process that updates data directly to DB, thus doesn't trigger the usual indexing events.

To make sure updated products make it into the index, we're using the following as necessary;
`Mage::getModel('algoliasearch/indexer_algolia')->reindexSpecificProducts($productId);`

However that caused issues within the producthelper, specifically relating to it assuming that it will always have the stock item data inside the collection.

I've added the check & fetch condition for main and sub_products within `Algolia_Algoliasearch_Helper_Entity_Producthelper::getObject()`

Tested against Magento 1.7 specifically, (running in production), should work for all recent versions.
