### PR TITLE
Remove `obscure` type from API key config setting. It causes issues on …

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/etc/system.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/system.xml
@@ -118,7 +118,7 @@
                         </application_id>
                         <api_key translate="label">
                             <label>Admin API key</label>
-                            <frontend_type>obscure</frontend_type>
+                            <frontend_type>password</frontend_type>
                             <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>


### PR DESCRIPTION
… different Magento instances.