### PR TITLE
Bugfix, no search results when Algolia is disabled

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Model/Resource/Fulltext/Collection.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Resource/Fulltext/Collection.php
@@ -46,7 +46,7 @@ class Algolia_Algoliasearch_Model_Resource_Fulltext_Collection extends Mage_Cata
         $storeId = Mage::app()->getStore()->getId();
 
         if (!$config->getApplicationID() || !$config->getAPIKey() || $config->isEnabledFrontEnd($storeId) === false) {
-            return parent::getFoundIds();
+            return false;
         }
 
         $data = array();


### PR DESCRIPTION
When Algolia is disabled with `algoliasearch/credentials/enable_backend` for a store it's not returning any search results.