### PR TITLE
Disabling Search and Indexing options are independant

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Config.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Config.php
@@ -145,8 +145,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     public function isEnabledFrontEnd($storeId = null)
     {
         // Frontend = Backend + Frontent
-        return Mage::getStoreConfigFlag(self::ENABLE_BACKEND,
-            $storeId) && Mage::getStoreConfigFlag(self::ENABLE_FRONTEND, $storeId);
+        return Mage::getStoreConfigFlag(self::ENABLE_FRONTEND, $storeId);
     }
 
     public function isEnabledBackend($storeId = null)

--- a/app/code/community/Algolia/Algoliasearch/etc/system.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/system.xml
@@ -70,7 +70,7 @@
                     </comment>
                     <fields>
                         <enable_backend translate="label comment">
-                            <label>Enable Extension</label>
+                            <label>Enable Indexing</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>0</sort_order>
@@ -79,7 +79,7 @@
                             <show_in_store>1</show_in_store>
                             <comment>
                                 <![CDATA[
-                                If set to No, Algolia extension will simply be disabled.
+                                If set to No, Algolia extension will not index your data automatically.
                                 ]]>
                             </comment>
                         </enable_backend>
@@ -87,11 +87,10 @@
                             <label>Enable Search</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>0</sort_order>
+                            <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <depends><enable_backend>1</enable_backend></depends>
                             <comment>
                                 <![CDATA[
                                 If set to No, search will be done by Magento but indexing will be done by Algolia
@@ -102,11 +101,10 @@
                             <label>Enable Logging</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>0</sort_order>
+                            <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <depends><enable_backend>1</enable_backend></depends>
                             <comment>
                                 <![CDATA[
                                 NOTICE: Debug logging generates a significant amount of data and can affect performance of indexing


### PR DESCRIPTION
* The option called _Enable Extension_ was renamed to _Enable Indexing_, the good news is that the code was actually written this way.
* `isEnabledFrontEnd()` method only relies on Frontend option
* In config admin page, _Enable frontend_ and _Enable Logging_ don't rely on _Enable Indexing_ anymore.

See: https://discourse.algolia.com/t/using-main-web-search-on-all-store-locations/697