### PR TITLE
Make indexing and search options independant

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Config.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Config.php
@@ -150,9 +150,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
 
     public function isEnabledFrontEnd($storeId = null)
     {
-        // Frontend = Backend + Frontent
-        return Mage::getStoreConfigFlag(self::ENABLE_BACKEND,
-            $storeId) && Mage::getStoreConfigFlag(self::ENABLE_FRONTEND, $storeId);
+        return Mage::getStoreConfigFlag(self::ENABLE_FRONTEND, $storeId);
     }
 
     public function isEnabledBackend($storeId = null)

--- a/app/code/community/Algolia/Algoliasearch/etc/system.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/system.xml
@@ -70,7 +70,7 @@
                     </comment>
                     <fields>
                         <enable_backend translate="label comment">
-                            <label>Enable Extension</label>
+                            <label>Enable Indexing</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>0</sort_order>
@@ -79,7 +79,7 @@
                             <show_in_store>1</show_in_store>
                             <comment>
                                 <![CDATA[
-                                If set to No, Algolia extension will simply be disabled.
+                                If set to No, Algolia extension will not index your data automatically.
                                 ]]>
                             </comment>
                         </enable_backend>
@@ -87,11 +87,10 @@
                             <label>Enable Search</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>0</sort_order>
+                            <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <depends><enable_backend>1</enable_backend></depends>
                             <comment>
                                 <![CDATA[
                                 If set to No, search will be done by Magento but indexing will be done by Algolia
@@ -102,11 +101,10 @@
                             <label>Enable Logging</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>0</sort_order>
+                            <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <depends><enable_backend>1</enable_backend></depends>
                             <comment>
                                 <![CDATA[
                                 NOTICE: Debug logging generates a significant amount of data and can affect performance of indexing

--- a/dev/bin/test.sh
+++ b/dev/bin/test.sh
@@ -5,7 +5,7 @@ echo -e "\e[93m-- Starting Apache and MySQL services --\e[0m"
 service mysql start
 service apache2 start
 
-if [ $TRAVIS == true ]; then
+if [ "$TRAVIS" == true ]; then
   echo -e "\n\e[93m-- Setting the correct rights to Magento files --\e[0m"
   chmod -R 777 /var/www/htdocs
   chown -R www-data:www-data /var/www/htdocs
@@ -34,4 +34,9 @@ chown -R www-data:www-data /var/www/htdocs/media
 # Run tests
 echo -e "\n\e[93m-- Running the tests --\e[0m"
 cd /var/www/htdocs/.modman/algoliasearch-magento
-vendor/bin/phpunit tests
+
+if [ $FILTER ]; then
+    vendor/bin/phpunit tests --filter "$FILTER"
+else
+    vendor/bin/phpunit tests
+fi

--- a/dev/runTests.sh
+++ b/dev/runTests.sh
@@ -24,6 +24,7 @@ usage() {
   echo "   -h | --help                         Print this help" >&2
   echo "   -v | --magento-version              Magento version [16, 17, 18, 19] (default: 19)" >&2
   echo "   -x | --xdebug                       Install xdebug in container (for code coverage)" >&2
+  echo "   -f | --filter                       PHPUnit filter to use" >&2
 }
 
 while [[ $# > 0 ]]; do
@@ -61,6 +62,10 @@ while [[ $# > 0 ]]; do
       ;;
     -x|--xdebug)
       INSTALL_XDEBUG="Yes"
+      shift
+      ;;
+    -f|--filter)
+      FILTER="$2"
       shift
       ;;
     -h|--help)
@@ -132,6 +137,9 @@ echo "        INDEX_PREFIX: $INDEX_PREFIX"
 echo "            BASE_URL: $BASE_URL"
 echo "     MAGENTO VERSION: $MAGENTO_VERSION"
 echo "      INSTALL XDEBUG: $INSTALL_XDEBUG"
+if [ $FILTER ]; then
+    echo "              FILTER: $FILTER"
+fi
 echo ""
 
 docker run \
@@ -142,6 +150,7 @@ docker run \
   -e INDEX_PREFIX=$INDEX_PREFIX \
   -e BASE_URL=$BASE_URL \
   -e TRAVIS=$TRAVIS \
+  -e FILTER=$FILTER \
   --dns=208.67.222.222 \
   --name test-algoliasearch-magento \
   -t algolia/test-algoliasearch-magento

--- a/tests/AbstractIndexingTestCase.php
+++ b/tests/AbstractIndexingTestCase.php
@@ -7,9 +7,15 @@ class AbstractIndexingTestCase extends TestCase
     /** @var Algolia_Algoliasearch_Helper_Algoliahelper */
     protected $algoliaHelper;
 
+    protected $indexPrefix;
+
     public function setUp()
     {
         $this->algoliaHelper = Mage::helper('algoliasearch/algoliahelper');
+
+        /** @var Algolia_Algoliasearch_Helper_Config $config */
+        $config = Mage::helper('algoliasearch/config');
+        $this->indexPrefix = $config->getIndexPrefix();
 
         setConfig('algoliasearch/queue/active', '0');
 
@@ -21,21 +27,17 @@ class AbstractIndexingTestCase extends TestCase
 
     protected function processTest(Algolia_Algoliasearch_Model_Indexer_Abstract $indexer, $indexSuffix, $expectedNbHits, $expectedNbHitsFrench = null, $expectedNbHitsGerman = null)
     {
-        /** @var Algolia_Algoliasearch_Helper_Config $config */
-        $config = Mage::helper('algoliasearch/config');
-        $indexPrefix = $config->getIndexPrefix();
-
-        $this->algoliaHelper->clearIndex($indexPrefix.'default_'.$indexSuffix);
-        $this->algoliaHelper->clearIndex($indexPrefix.'french_'.$indexSuffix);
-        $this->algoliaHelper->clearIndex($indexPrefix.'german_'.$indexSuffix);
+        $this->algoliaHelper->clearIndex($this->indexPrefix.'default_'.$indexSuffix);
+        $this->algoliaHelper->clearIndex($this->indexPrefix.'french_'.$indexSuffix);
+        $this->algoliaHelper->clearIndex($this->indexPrefix.'german_'.$indexSuffix);
 
         $indexer->reindexAll();
 
         $this->algoliaHelper->waitLastTask();
 
-        $resultsDefault = $this->algoliaHelper->query($indexPrefix.'default_'.$indexSuffix, '', array());
-        $resultsFrench = $this->algoliaHelper->query($indexPrefix.'french_'.$indexSuffix, '', array());
-        $resultsGerman = $this->algoliaHelper->query($indexPrefix.'german_'.$indexSuffix, '', array());
+        $resultsDefault = $this->algoliaHelper->query($this->indexPrefix.'default_'.$indexSuffix, '', array());
+        $resultsFrench = $this->algoliaHelper->query($this->indexPrefix.'french_'.$indexSuffix, '', array());
+        $resultsGerman = $this->algoliaHelper->query($this->indexPrefix.'german_'.$indexSuffix, '', array());
 
         $expectedNbHitsFrench = $expectedNbHitsFrench ?: $expectedNbHits;
         $expectedNbHitsGerman = $expectedNbHitsGerman ?: $expectedNbHits;
@@ -43,5 +45,12 @@ class AbstractIndexingTestCase extends TestCase
         $this->assertEquals($expectedNbHits, $resultsDefault['nbHits']);
         $this->assertEquals($expectedNbHitsFrench, $resultsFrench['nbHits']);
         $this->assertEquals($expectedNbHitsGerman, $resultsGerman['nbHits']);
+    }
+
+    public function processQueryOneProduct()
+    {
+        $resultsDefault = $this->algoliaHelper->query($this->indexPrefix.'default_products', 'lemon flower', array());
+
+        $this->assertEquals(1, $resultsDefault['nbHits']);
     }
 }

--- a/tests/AbstractIndexingTestCase.php
+++ b/tests/AbstractIndexingTestCase.php
@@ -1,28 +1,20 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-class AbstractIndexingTestCase extends TestCase
+class AbstractIndexingTestCase extends AbstractTestCase
 {
     /** @var Algolia_Algoliasearch_Helper_Algoliahelper */
     protected $algoliaHelper;
 
-    protected $indexPrefix;
-
     public function setUp()
     {
-        $this->algoliaHelper = Mage::helper('algoliasearch/algoliahelper');
-
-        /** @var Algolia_Algoliasearch_Helper_Config $config */
-        $config = Mage::helper('algoliasearch/config');
-        $this->indexPrefix = $config->getIndexPrefix();
-
-        setConfig('algoliasearch/queue/active', '0');
+        parent::setUp();
 
         $extraSettingsSections = array('products', 'categories', 'pages', 'suggestions');
         foreach ($extraSettingsSections as $section) {
             setConfig('algoliasearch/advanced_settings/'.$section.'_extra_settings', '');
         }
+
+        $this->algoliaHelper = Mage::helper('algoliasearch/algoliahelper');
     }
 
     protected function processTest(Algolia_Algoliasearch_Model_Indexer_Abstract $indexer, $indexSuffix, $expectedNbHits, $expectedNbHitsFrench = null, $expectedNbHitsGerman = null)
@@ -45,12 +37,5 @@ class AbstractIndexingTestCase extends TestCase
         $this->assertEquals($expectedNbHits, $resultsDefault['nbHits']);
         $this->assertEquals($expectedNbHitsFrench, $resultsFrench['nbHits']);
         $this->assertEquals($expectedNbHitsGerman, $resultsGerman['nbHits']);
-    }
-
-    public function processQueryOneProduct()
-    {
-        $resultsDefault = $this->algoliaHelper->query($this->indexPrefix.'default_products', 'lemon flower', array());
-
-        $this->assertEquals(1, $resultsDefault['nbHits']);
     }
 }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -1,0 +1,28 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class AbstractTestCase extends TestCase
+{
+    protected $indexPrefix;
+
+    /**
+     * @var array Default value of general store settings (not related to algolia's extention)
+     */
+    protected $defaultConfig = array(
+        'cataloginventory/options/show_out_of_stock' => '0',
+    );
+
+    public function setUp()
+    {
+        /** @var Algolia_Algoliasearch_Helper_Config $config */
+        $config = Mage::helper('algoliasearch/config');
+        $this->indexPrefix = $config->getIndexPrefix();
+
+        foreach ($this->defaultConfig as $name => $value) {
+            setConfig($name, $value);
+        }
+
+        resetConfigs();
+    }
+}

--- a/tests/CategoriesIndexingTest.php
+++ b/tests/CategoriesIndexingTest.php
@@ -10,10 +10,6 @@ class CategoriesIndexingTest extends AbstractIndexingTestCase
 
     public function testDefaultIndexableAttributes()
     {
-        /** @var Algolia_Algoliasearch_Helper_Config $config */
-        $config = Mage::helper('algoliasearch/config');
-        $indexPrefix = $config->getIndexPrefix();
-
         setConfig('algoliasearch/categories/category_additional_attributes2', serialize(array()));
 
         $indexer = new Algolia_Algoliasearch_Model_Indexer_Algoliacategories();
@@ -21,7 +17,7 @@ class CategoriesIndexingTest extends AbstractIndexingTestCase
 
         $this->algoliaHelper->waitLastTask();
 
-        $results = $this->algoliaHelper->query($indexPrefix.'default_categories', '', array('hitsPerPage' => 1));
+        $results = $this->algoliaHelper->query($this->indexPrefix.'default_categories', '', array('hitsPerPage' => 1));
         $hit = reset($results['hits']);
 
         $defaultAttributes = array(

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -49,7 +49,7 @@ class ConfigTest extends TestCase
         $this->assertEquals(count($facets), $attributesMatched);
     }
 
-    public function testAutomaticalSetOfCategoriesFacet()
+    public function testAutomaticSetOfCategoriesFacet()
     {
         // Remove categories from facets
         $facets = $this->config->getFacets();

--- a/tests/PagesIndexingTest.php
+++ b/tests/PagesIndexingTest.php
@@ -24,13 +24,8 @@ class PagesIndexingTest extends AbstractIndexingTestCase
         $indexer = new Algolia_Algoliasearch_Model_Indexer_Algoliapages();
         $this->processTest($indexer, 'pages', 8, 7, 7);
 
-
-        /** @var Algolia_Algoliasearch_Helper_Config $config */
-        $config = Mage::helper('algoliasearch/config');
-        $indexPrefix = $config->getIndexPrefix();
-
         foreach (array('default', 'french', 'german') as $store) {
-            $results = $this->algoliaHelper->query($indexPrefix.$store.'_pages', '', array());
+            $results = $this->algoliaHelper->query($this->indexPrefix.$store.'_pages', '', array());
 
             $noRoutePageExists = false;
             $homePageExists = false;
@@ -53,16 +48,12 @@ class PagesIndexingTest extends AbstractIndexingTestCase
 
     public function testDefaultIndexableAttributes()
     {
-        /** @var Algolia_Algoliasearch_Helper_Config $config */
-        $config = Mage::helper('algoliasearch/config');
-        $indexPrefix = $config->getIndexPrefix();
-
         $indexer = new Algolia_Algoliasearch_Model_Indexer_Algoliapages();
         $indexer->reindexAll();
 
         $this->algoliaHelper->waitLastTask();
 
-        $results = $this->algoliaHelper->query($indexPrefix.'default_pages', '', array('hitsPerPage' => 1));
+        $results = $this->algoliaHelper->query($this->indexPrefix.'default_pages', '', array('hitsPerPage' => 1));
         $hit = reset($results['hits']);
 
         $defaultAttributes = array(

--- a/tests/ProductsIndexingTest.php
+++ b/tests/ProductsIndexingTest.php
@@ -2,7 +2,7 @@
 
 class ProductsIndexingTest extends AbstractIndexingTestCase
 {
-    public function testProductsAllVisibile()
+    public function testProductsAllVisible()
     {
         setConfig('algoliasearch/products/index_visibility', 'all');
         setConfig('cataloginventory/options/show_out_of_stock', '0');
@@ -11,7 +11,7 @@ class ProductsIndexingTest extends AbstractIndexingTestCase
         $this->processTest($productIndexer, 'products', 86);
     }
 
-    public function testProductsOnlySearchVisibile()
+    public function testProductsOnlySearchVisible()
     {
         setConfig('algoliasearch/products/index_visibility', 'only_search');
         setConfig('cataloginventory/options/show_out_of_stock', '0');
@@ -20,7 +20,7 @@ class ProductsIndexingTest extends AbstractIndexingTestCase
         $this->processTest($productIndexer, 'products', 85);
     }
 
-    public function testProductsOnlyCatalogVisibile()
+    public function testProductsOnlyCatalogVisible()
     {
         setConfig('algoliasearch/products/index_visibility', 'only_catalog');
         setConfig('cataloginventory/options/show_out_of_stock', '0');

--- a/tests/ProductsIndexingTest.php
+++ b/tests/ProductsIndexingTest.php
@@ -107,4 +107,15 @@ class ProductsIndexingTest extends AbstractIndexingTestCase
         $productIndexer = new Algolia_Algoliasearch_Model_Indexer_Algolia();
         $this->processTest($productIndexer, 'products', 86);
     }
+
+    public function testProductAreSearchableIfIndexingIsDisabled()
+    {
+        // Turn off logging to avoid messages between PHPUnit dots
+        setConfig('algoliasearch/credentials/debug', '0');
+
+        setConfig('algoliasearch/credentials/enable_backend', '0');
+        $this->processQueryOneProduct();
+
+        setConfig('algoliasearch/credentials/debug', '1');
+    }
 }

--- a/tests/ProductsIndexingTest.php
+++ b/tests/ProductsIndexingTest.php
@@ -91,4 +91,20 @@ class ProductsIndexingTest extends AbstractIndexingTestCase
         $extraAttributes = implode(', ', array_keys($hit));
         $this->assertTrue(empty($hit), 'Extra products attributes ('.$extraAttributes.') are indexed and should not be.');
     }
+
+    public function testIfIndexingCanBeEnabledAndDisabled()
+    {
+        // Turn off logging to avoid messages between PHPUnit dots
+        setConfig('algoliasearch/credentials/debug', '0');
+
+        setConfig('algoliasearch/credentials/enable_backend', '0');
+
+        $productIndexer = new Algolia_Algoliasearch_Model_Indexer_Algolia();
+        $this->processTest($productIndexer, 'products', 0);
+
+        setConfig('algoliasearch/credentials/enable_backend', '1');
+
+        $productIndexer = new Algolia_Algoliasearch_Model_Indexer_Algolia();
+        $this->processTest($productIndexer, 'products', 86);
+    }
 }

--- a/tests/ProductsIndexingTest.php
+++ b/tests/ProductsIndexingTest.php
@@ -2,19 +2,17 @@
 
 class ProductsIndexingTest extends AbstractIndexingTestCase
 {
+    const DEFAULT_PRODUCT_COUNT = 86;
+
     public function testProductsAllVisible()
     {
-        setConfig('algoliasearch/products/index_visibility', 'all');
-        setConfig('cataloginventory/options/show_out_of_stock', '0');
-
         $productIndexer = new Algolia_Algoliasearch_Model_Indexer_Algolia();
-        $this->processTest($productIndexer, 'products', 86);
+        $this->processTest($productIndexer, 'products', self::DEFAULT_PRODUCT_COUNT);
     }
 
     public function testProductsOnlySearchVisible()
     {
         setConfig('algoliasearch/products/index_visibility', 'only_search');
-        setConfig('cataloginventory/options/show_out_of_stock', '0');
 
         $productIndexer = new Algolia_Algoliasearch_Model_Indexer_Algolia();
         $this->processTest($productIndexer, 'products', 85);
@@ -23,24 +21,19 @@ class ProductsIndexingTest extends AbstractIndexingTestCase
     public function testProductsOnlyCatalogVisible()
     {
         setConfig('algoliasearch/products/index_visibility', 'only_catalog');
-        setConfig('cataloginventory/options/show_out_of_stock', '0');
 
         $productIndexer = new Algolia_Algoliasearch_Model_Indexer_Algolia();
-        $this->processTest($productIndexer, 'products', 86);
+        $this->processTest($productIndexer, 'products', self::DEFAULT_PRODUCT_COUNT);
     }
 
     public function testProductsOnInStock()
     {
-        setConfig('algoliasearch/products/index_visibility', 'all');
-        setConfig('cataloginventory/options/show_out_of_stock', '0');
-
         $productIndexer = new Algolia_Algoliasearch_Model_Indexer_Algolia();
-        $this->processTest($productIndexer, 'products', 86);
+        $this->processTest($productIndexer, 'products', self::DEFAULT_PRODUCT_COUNT);
     }
 
     public function testProductsIncludingOutOfStock()
     {
-        setConfig('algoliasearch/products/index_visibility', 'all');
         setConfig('cataloginventory/options/show_out_of_stock', '1');
 
         $productIndexer = new Algolia_Algoliasearch_Model_Indexer_Algolia();
@@ -49,10 +42,6 @@ class ProductsIndexingTest extends AbstractIndexingTestCase
 
     public function testDefaultIndexableAttributes()
     {
-        /** @var Algolia_Algoliasearch_Helper_Config $config */
-        $config = Mage::helper('algoliasearch/config');
-        $indexPrefix = $config->getIndexPrefix();
-
         setConfig('algoliasearch/products/product_additional_attributes', serialize(array()));
         setConfig('algoliasearch/instant/facets', serialize(array()));
         setConfig('algoliasearch/instant/sorts', serialize(array()));
@@ -63,7 +52,7 @@ class ProductsIndexingTest extends AbstractIndexingTestCase
 
         $this->algoliaHelper->waitLastTask();
 
-        $results = $this->algoliaHelper->query($indexPrefix.'default_products', '', array('hitsPerPage' => 1));
+        $results = $this->algoliaHelper->query($this->indexPrefix.'default_products', '', array('hitsPerPage' => 1));
         $hit = reset($results['hits']);
 
         $defaultAttributes = array(
@@ -94,9 +83,6 @@ class ProductsIndexingTest extends AbstractIndexingTestCase
 
     public function testIfIndexingCanBeEnabledAndDisabled()
     {
-        // Turn off logging to avoid messages between PHPUnit dots
-        setConfig('algoliasearch/credentials/debug', '0');
-
         setConfig('algoliasearch/credentials/enable_backend', '0');
 
         $productIndexer = new Algolia_Algoliasearch_Model_Indexer_Algolia();
@@ -105,17 +91,15 @@ class ProductsIndexingTest extends AbstractIndexingTestCase
         setConfig('algoliasearch/credentials/enable_backend', '1');
 
         $productIndexer = new Algolia_Algoliasearch_Model_Indexer_Algolia();
-        $this->processTest($productIndexer, 'products', 86);
+        $this->processTest($productIndexer, 'products', self::DEFAULT_PRODUCT_COUNT);
     }
 
     public function testProductAreSearchableIfIndexingIsDisabled()
     {
-        // Turn off logging to avoid messages between PHPUnit dots
-        setConfig('algoliasearch/credentials/debug', '0');
-
         setConfig('algoliasearch/credentials/enable_backend', '0');
-        $this->processQueryOneProduct();
 
-        setConfig('algoliasearch/credentials/debug', '1');
+        $resultsDefault = $this->algoliaHelper->query($this->indexPrefix.'default_products', 'lemon flower', array());
+
+        $this->assertEquals(1, $resultsDefault['nbHits']);
     }
 }

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
-class QueueTest extends TestCase
+class QueueTest extends AbstractTestCase
 {
     /** @var Varien_Db_Adapter_Interface */
     private $readConnection;
@@ -12,6 +10,8 @@ class QueueTest extends TestCase
 
     public function setUp()
     {
+        parent::setUp();
+
         /** @var Mage_Core_Model_Resource $resource */
         $resource = Mage::getSingleton('core/resource');
 
@@ -58,10 +58,6 @@ class QueueTest extends TestCase
     /** @depends testFill */
     public function testExecute()
     {
-        /** @var Algolia_Algoliasearch_Helper_Config $config */
-        $config = Mage::helper('algoliasearch/config');
-        $indexPrefix = $config->getIndexPrefix();
-
         /** @var Algolia_Algoliasearch_Helper_Algoliahelper $algoliaHelper */
         $algoliaHelper = Mage::helper('algoliasearch/algoliahelper');
 
@@ -78,15 +74,15 @@ class QueueTest extends TestCase
         $existsDefaultTmpIndex = false;
         $existsFrenchTmpIndex = false;
         foreach ($indices['items'] as $index) {
-            if ($index['name'] === $indexPrefix.'default_products') {
+            if ($index['name'] === $this->indexPrefix.'default_products') {
                 $existsDefaultProdIndex = true;
             }
 
-            if ($index['name'] === $indexPrefix.'default_products_tmp') {
+            if ($index['name'] === $this->indexPrefix.'default_products_tmp') {
                 $existsDefaultTmpIndex = true;
             }
 
-            if ($index['name'] === $indexPrefix.'french_products_tmp') {
+            if ($index['name'] === $this->indexPrefix.'french_products_tmp') {
                 $existsFrenchTmpIndex = true;
             }
         }
@@ -109,27 +105,27 @@ class QueueTest extends TestCase
         $existsFrenchTmpIndex = false;
         $existsGermanTmpIndex = false;
         foreach ($indices['items'] as $index) {
-            if ($index['name'] === $indexPrefix.'default_products') {
+            if ($index['name'] === $this->indexPrefix.'default_products') {
                 $existsDefaultProdIndex = true;
             }
 
-            if ($index['name'] === $indexPrefix.'french_products') {
+            if ($index['name'] === $this->indexPrefix.'french_products') {
                 $existsFrenchProdIndex = true;
             }
 
-            if ($index['name'] === $indexPrefix.'german_products') {
+            if ($index['name'] === $this->indexPrefix.'german_products') {
                 $existsGermanProdIndex = true;
             }
 
-            if ($index['name'] === $indexPrefix.'default_products_tmp') {
+            if ($index['name'] === $this->indexPrefix.'default_products_tmp') {
                 $existsDefaultTmpIndex = true;
             }
 
-            if ($index['name'] === $indexPrefix.'french_products_tmp') {
+            if ($index['name'] === $this->indexPrefix.'french_products_tmp') {
                 $existsFrenchTmpIndex = true;
             }
 
-            if ($index['name'] === $indexPrefix.'german_products_tmp') {
+            if ($index['name'] === $this->indexPrefix.'german_products_tmp') {
                 $existsGermanTmpIndex = true;
             }
         }
@@ -176,19 +172,15 @@ class QueueTest extends TestCase
         $algoliaHelper = Mage::helper('algoliasearch/algoliahelper');
         $algoliaHelper->waitLastTask();
 
-        /** @var Algolia_Algoliasearch_Helper_Config $config */
-        $config = Mage::helper('algoliasearch/config');
-        $indexPrefix = $config->getIndexPrefix();
-
-        $settings = $algoliaHelper->getIndex($indexPrefix.'default_products')->getSettings();
+        $settings = $algoliaHelper->getIndex($this->indexPrefix.'default_products')->getSettings();
         $this->assertFalse(empty($settings['attributesForFaceting']), 'AttributesForFacetting should be set, but they are not.');
         $this->assertFalse(empty($settings['searchableAttributes']), 'SearchableAttributes should be set, but they are not.');
 
-        $settings = $algoliaHelper->getIndex($indexPrefix.'french_products')->getSettings();
+        $settings = $algoliaHelper->getIndex($this->indexPrefix.'french_products')->getSettings();
         $this->assertFalse(empty($settings['attributesForFaceting']), 'AttributesForFacetting should be set, but they are not.');
         $this->assertFalse(empty($settings['searchableAttributes']), 'SearchableAttributes should be set, but they are not.');
 
-        $settings = $algoliaHelper->getIndex($indexPrefix.'german_products')->getSettings();
+        $settings = $algoliaHelper->getIndex($this->indexPrefix.'german_products')->getSettings();
         $this->assertFalse(empty($settings['attributesForFaceting']), 'AttributesForFacetting should be set, but they are not.');
         $this->assertFalse(empty($settings['searchableAttributes']), 'SearchableAttributes should be set, but they are not.');
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,8 +7,6 @@ include __DIR__.'/../../../app/Mage.php';
 
 Mage::app()->setCurrentStore(Mage_Core_Model_App::ADMIN_STORE_ID);
 
-setConfig('dev/log/active', '1');
-
 // Set Magento's base URLs
 setConfig('web/secure/base_url', getenv('BASE_URL'));
 setConfig('web/unsecure/base_url', getenv('BASE_URL'));
@@ -29,9 +27,17 @@ function resetConfigs($configs = array())
 
     $xml = simplexml_load_file($configXmlFile);
 
+    $credentialsShortcuts = array(
+        'credentials/application_id', 'credentials/api_key', 'credentials/search_only_api_key', 'credentials/index_prefix'
+    );
+
     foreach ($xml->default->algoliasearch->children() as $section => $subsections) {
         foreach ($subsections as $subsectionName => $subsection) {
             $shortcut = $section.'/'.$subsectionName;
+
+            if (in_array($shortcut, $credentialsShortcuts)) {
+                continue;
+            }
 
             if (!empty($configs) && !in_array($shortcut, $configs, true)) {
                 continue;


### PR DESCRIPTION
This means that if you turn off indexing, for whatever reasons, your can still search them on your frontend.

I think it's better to not delete the indices when the indexing option is turned off because you might need to turn it off temporarily (maintenance, debugging or so) but you still want your frontend to have the Algolia search bar.

**Related:**
* Previous PR #792
* https://discourse.algolia.com/t/using-main-web-search-on-all-store-locations/697

## Notes
 * I added a filter option to the `runTests.sh` script so we can choose which tests to run while developing 🎉 
 * Default configuration is now re-applied before each tets
