### PR TITLE
Enable Rewrite for Algolia_Algoliasearch_Model_Resource_Engine

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Model/Indexer/Abstract.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Indexer/Abstract.php
@@ -11,7 +11,7 @@ abstract class Algolia_Algoliasearch_Model_Indexer_Abstract extends Mage_Index_M
     {
         parent::__construct();
 
-        $this->engine = new Algolia_Algoliasearch_Model_Resource_Engine();
+        $this->engine = Mage::getResourceModel('algoliasearch/engine');
     }
 
     /**

--- a/app/code/community/Algolia/Algoliasearch/Model/Resource/Engine.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Resource/Engine.php
@@ -75,9 +75,9 @@ class Algolia_Algoliasearch_Model_Resource_Engine extends Mage_CatalogSearch_Mod
 
     public function rebuildCategoryIndex($storeId = null, $categoryIds = null)
     {
-        $ids = Algolia_Algoliasearch_Helper_Entity_Helper::getStores($storeId);
+        $storeIds = Algolia_Algoliasearch_Helper_Entity_Helper::getStores($storeId);
 
-        foreach ($ids as $id) {
+        foreach ($storeIds as $storeId) {
             $by_page = $this->config->getNumberOfElementByPage();
 
             if (is_array($categoryIds) && count($categoryIds) > $by_page) {
@@ -85,7 +85,7 @@ class Algolia_Algoliasearch_Model_Resource_Engine extends Mage_CatalogSearch_Mod
                     $this->_rebuildCategoryIndex($storeId, $chunk);
                 }
             } else {
-                $this->_rebuildCategoryIndex($id, $categoryIds);
+                $this->_rebuildCategoryIndex($storeId, $categoryIds);
             }
         }
 


### PR DESCRIPTION
The engine shouldn't be loaded via direct initialization and should instead follow Magento best practice to allow rewrites by third party developers.