### PR TITLE
Turn off the synonyms management by default

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/etc/config.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/config.xml
@@ -214,7 +214,7 @@
                 <push_initial_search>0</push_initial_search>
             </analytics>
             <synonyms>
-                <enable_synonyms>1</enable_synonyms>
+                <enable_synonyms>0</enable_synonyms>
             </synonyms>
             <advanced>
                 <remove_words_if_no_result>allOptional</remove_words_if_no_result>


### PR DESCRIPTION
Leads to an unexpected behavior when customers are managing synonyms in dashboard and then upgrade to the new version with synonyms management, which leads to wiped out synonyms.

cc @mikaa123 