### PR TITLE
Prevent backend rendering

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Config.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Config.php
@@ -73,6 +73,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     const INDEX_PRODUCT_ON_CATEGORY_PRODUCTS_UPDATE = 'algoliasearch/advanced/index_product_on_category_products_update';
     const INDEX_ALL_CATEGORY_PRODUCTS_ON_CATEGORY_UPDATE = 'algoliasearch/advanced/index_all_category_product_on_category_update';
     const PREVENT_BACKEND_RENDERING = 'algoliasearch/advanced/prevent_backend_rendering';
+    const BACKEND_RENDERING_ALLOWED_USER_AGENTS = 'algoliasearch/advanced/backend_rendering_allowed_user_agents';
 
     const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
     const LOGGING_ENABLED = 'algoliasearch/credentials/debug';
@@ -608,11 +609,31 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
 
     public function preventBackendRendering($storeId = null)
     {
-        if ($this->replaceCategories($storeId) === true) {
-            return Mage::getStoreConfigFlag(self::PREVENT_BACKEND_RENDERING, $storeId);
+        $preventBackendRendering = Mage::getStoreConfigFlag(self::PREVENT_BACKEND_RENDERING, $storeId);
+
+        if ($preventBackendRendering === false) {
+            return false;
         }
 
-        return false;
+        $userAgent = mb_strtolower($_SERVER['HTTP_USER_AGENT'], 'utf-8');
+
+        $allowedUserAgents = Mage::getStoreConfig(self::BACKEND_RENDERING_ALLOWED_USER_AGENTS, $storeId);
+        $allowedUserAgents = trim($allowedUserAgents);
+
+        if ($allowedUserAgents === '') {
+            return true;
+        }
+
+        $allowedUserAgents = explode("\n", $allowedUserAgents);
+
+        foreach ($allowedUserAgents as $allowedUserAgent) {
+            $allowedUserAgent = mb_strtolower($allowedUserAgent, 'utf-8');
+            if (strpos($userAgent, $allowedUserAgent) !== false) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function getCustomRanking($configName, $storeId = null)

--- a/app/code/community/Algolia/Algoliasearch/Helper/Config.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Config.php
@@ -72,6 +72,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     const AUTOCOMPLETE_SELECTOR = 'algoliasearch/advanced/autocomplete_selector';
     const INDEX_PRODUCT_ON_CATEGORY_PRODUCTS_UPDATE = 'algoliasearch/advanced/index_product_on_category_products_update';
     const INDEX_ALL_CATEGORY_PRODUCTS_ON_CATEGORY_UPDATE = 'algoliasearch/advanced/index_all_category_product_on_category_update';
+    const PREVENT_BACKEND_RENDERING = 'algoliasearch/advanced/prevent_backend_rendering';
 
     const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
     const LOGGING_ENABLED = 'algoliasearch/credentials/debug';
@@ -603,6 +604,15 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
         $constant = 'EXTRA_SETTINGS_'.mb_strtoupper($section);
 
         return trim(Mage::getStoreConfig(constant('self::'.$constant), $storeId));
+    }
+
+    public function preventBackendRendering($storeId = null)
+    {
+        if ($this->replaceCategories($storeId) === true) {
+            return Mage::getStoreConfigFlag(self::PREVENT_BACKEND_RENDERING, $storeId);
+        }
+
+        return false;
     }
 
     private function getCustomRanking($configName, $storeId = null)

--- a/app/code/community/Algolia/Algoliasearch/Model/Observer.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Observer.php
@@ -76,6 +76,10 @@ class Algolia_Algoliasearch_Model_Observer
                     } else {
                         $observer->getLayout()->getUpdate()->addHandle('algolia_search_handle_no_topsearch');
                     }
+
+                    if ($this->config->preventBackendRendering() === true) {
+                        $observer->getLayout()->getUpdate()->addHandle('algolia_search_handle_prevent_backend_rendering');
+                    }
                 }
             }
         }

--- a/app/code/community/Algolia/Algoliasearch/etc/config.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/config.xml
@@ -236,6 +236,7 @@
                 <autocomplete_selector>.algolia-search-input</autocomplete_selector>
                 <index_product_on_category_products_update>1</index_product_on_category_products_update>
                 <index_all_category_product_on_category_update>0</index_all_category_product_on_category_update>
+                <prevent_backend_rendering>0</prevent_backend_rendering>
             </advanced>
             <product_map>
                 <!--

--- a/app/code/community/Algolia/Algoliasearch/etc/config.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/config.xml
@@ -237,6 +237,8 @@
                 <index_product_on_category_products_update>1</index_product_on_category_products_update>
                 <index_all_category_product_on_category_update>0</index_all_category_product_on_category_update>
                 <prevent_backend_rendering>0</prevent_backend_rendering>
+                <backend_rendering_allowed_user_agents>Googlebot
+Bingbot</backend_rendering_allowed_user_agents>
             </advanced>
             <product_map>
                 <!--

--- a/app/code/community/Algolia/Algoliasearch/etc/system.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/system.xml
@@ -1083,6 +1083,20 @@
                                 ]]>
                             </comment>
                         </prevent_backend_rendering>
+                        <backend_rendering_allowed_user_agents translate="label comment">
+                            <label>Allow backend rendering for User Agents:</label>
+                            <frontend_type>textarea</frontend_type>
+                            <sort_order>100</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>
+                                <![CDATA[
+                                You can specify multiple User-Agents, just put one User-Agent per a line.
+                                ]]>
+                            </comment>
+                            <depends><prevent_backend_rendering>1</prevent_backend_rendering></depends>
+                        </backend_rendering_allowed_user_agents>
                     </fields>
                 </advanced>
                 <advanced_settings translate="label">

--- a/app/code/community/Algolia/Algoliasearch/etc/system.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/system.xml
@@ -1069,6 +1069,20 @@
                                 ]]>
                             </comment>
                         </index_all_category_product_on_category_update>
+                        <prevent_backend_rendering translate="label comment">
+                            <label>Prevent backend rendering?</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>90</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>
+                                <![CDATA[
+                                FIXME
+                                ]]>
+                            </comment>
+                        </prevent_backend_rendering>
                     </fields>
                 </advanced>
                 <advanced_settings translate="label">

--- a/app/code/community/Algolia/Algoliasearch/etc/system.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/system.xml
@@ -1079,7 +1079,9 @@
                             <show_in_store>1</show_in_store>
                             <comment>
                                 <![CDATA[
-                                FIXME
+                                <span class="algolia-config-warning">&#9888;</span>
+                                By preventing your store from backend rendering you might break your SEO and accessibility of your store by search crawlers. Please, read documentation before you turn the backend rendering off:
+                                <a target="_blank" href="https://community.algolia.com/magento/doc/m1/prevent-backend-rendering/?utm_source=magento&utm_medium=extension&utm_campaign=magento_1&utm_term=shop-owner&utm_content=doc-link">Prevent Backend Rendering documentation</a>
                                 ]]>
                             </comment>
                         </prevent_backend_rendering>
@@ -1092,7 +1094,7 @@
                             <show_in_store>1</show_in_store>
                             <comment>
                                 <![CDATA[
-                                You can specify multiple User-Agents, just put one User-Agent per a line.
+                                To specify multiple User-Agents, please put one User-Agent per line.
                                 ]]>
                             </comment>
                             <depends><prevent_backend_rendering>1</prevent_backend_rendering></depends>

--- a/app/design/frontend/base/default/layout/algoliasearch.xml
+++ b/app/design/frontend/base/default/layout/algoliasearch.xml
@@ -63,4 +63,14 @@
             <block type="core/template" template="algoliasearch/autocomplete.phtml" name="algolia-autocomplete"/>
         </reference>
     </algolia_search_handle_no_topsearch>
+
+    <algolia_search_handle_prevent_backend_rendering>
+        <reference name="left_first">
+            <action method="unsetChild"><name>catalog.leftnav</name></action>
+        </reference>
+
+        <reference name="content">
+            <action method="unsetChild"><name>category.products</name></action>
+        </reference>
+    </algolia_search_handle_prevent_backend_rendering>
 </layout>

--- a/app/design/frontend/base/default/layout/algoliasearch.xml
+++ b/app/design/frontend/base/default/layout/algoliasearch.xml
@@ -67,10 +67,22 @@
     <algolia_search_handle_prevent_backend_rendering>
         <reference name="left_first">
             <action method="unsetChild"><name>catalog.leftnav</name></action>
+            <action method="unsetChild"><name>catalogsearch.leftnav</name></action>
+        </reference>
+
+        <reference name="left">
+            <action method="unsetChild"><name>tags_popular</name></action>
         </reference>
 
         <reference name="content">
             <action method="unsetChild"><name>category.products</name></action>
+            <action method="unsetChild"><name>search.result</name></action>
+        </reference>
+
+        <reference name="right">
+            <action method="unsetChild"><name>right.reports.product.viewed</name></action>
+            <action method="unsetChild"><name>left.reports.product.viewed</name></action>
+            <action method="unsetChild"><name>right.poll</name></action>
         </reference>
     </algolia_search_handle_prevent_backend_rendering>
 </layout>


### PR DESCRIPTION
This feature prevents category pages to be rendered on backed when they use Algolia. As a result the rendering should be much faster. Implements #877 

**TODO:**

- [x] User-agent detection to run backend rendering for specified UAs
- [x] Description of the configuration input
- [x] Documentation page (https://github.com/algolia/magento/pull/73)
- [x] Test accessibility of website