### PR TITLE
Use default for only_visible in product collection

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Model/Observer.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Observer.php
@@ -224,7 +224,7 @@ class Algolia_Algoliasearch_Model_Observer
             }
         } else {
             if (!empty($page) && !empty($pageSize)) {
-                $collection = $this->product_helper->getProductCollectionQuery($storeId, $productIds, $useTmpIndex);
+                $collection = $this->product_helper->getProductCollectionQuery($storeId, $productIds);
                 $this->helper->rebuildStoreProductIndexPage($storeId, $collection, $page, $pageSize, null, $productIds, $useTmpIndex);
             } else {
                 $this->helper->rebuildStoreProductIndex($storeId, $productIds);


### PR DESCRIPTION
It seems that useTmpIndex is used to determine if we should select only visible product or not.