### PR TITLE
Missing payload causes js console errors

### DIFF
--- a/js/algoliasearch/internals/frontend/common.js
+++ b/js/algoliasearch/internals/frontend/common.js
@@ -279,7 +279,7 @@ document.addEventListener("DOMContentLoaded", function (e) {
 					displayKey: 'query',
 					name: section.name,
 					templates: {
-						suggestion: function (hit) {
+						suggestion: function (hit, payload) {
 							if (hit.facet) {
 								hit.category = hit.facet.value;
 							}


### PR DESCRIPTION
**Summary**

When using autocomplete, this error ends up in the console:

Uncaught ReferenceError: payload is not defined
    at suggestion (common.js:295)
    at e (dataset.js:157)
    at Object.map (jquery.js:484)
    at r (dataset.js:141)
    at r._render (dataset.js:105)
    at t (dataset.js:202)
    at Object.callback (hits.js:20)
    at AlgoliaSearchCore.js:456

Refering to:
Line 295, hit.__queryID = payload.queryID;

(The js console errors were saved when using the master branch, so the line numbers is being a bit off from the PR which is for the developer branch)

**Result**

No more errors in the console! :)
