### PR TITLE
fix(refinementList): make search always active

### DIFF
--- a/js/algoliasearch/instantsearch.js
+++ b/js/algoliasearch/instantsearch.js
@@ -582,6 +582,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
     function addSearchForFacetValues(facet, options) {
         if (facet.searchable === '1') {
             options['searchForFacetValues'] = {
+								isAlwaysActive: true,
                 placeholder: algoliaConfig.translations.searchForFacetValuesPlaceholder,
                 templates: {
                     noResults: '<div class="sffv-no-results">' + algoliaConfig.translations.noResults + '</div>'


### PR DESCRIPTION
_This PR is aimed at starting a discussion :)_

With InstantSearch.js when a refinement list displays all the values, the search is disabled. There is an option that prevents this behavior: `isAlwaysActive`. 

It is particularly important when there are a lot of values, because the users can't see if the values are exhaustive or not. So either we just change the value (like in this PR) or we should expose the flag (and I will need help on that :D).