### PR TITLE
Improve name of "Remove inactive products" indexer

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Model/Indexer/Algoliadeleteproducts.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Indexer/Algoliadeleteproducts.php
@@ -18,7 +18,7 @@ class Algolia_Algoliasearch_Model_Indexer_Algoliadeleteproducts extends Algolia_
 
     public function getName()
     {
-        return Mage::helper('algoliasearch')->__('Algolia Search - Delete inactive products');
+        return Mage::helper('algoliasearch')->__('Algolia Search - Remove inactive products from Algolia');
     }
 
     public function getDescription()


### PR DESCRIPTION
The name is currently misleading and gives users a feeling that it'll delete inactive products from Magento DB completely. It only removed inactive products from Algolia so its' not appear in search. This commit explicitly mentions that it will remove it only from Algolia and not DB.

Fixes #1052