### PR TITLE
Fix special prices when customer groups are enabled

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
@@ -577,14 +577,14 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
                                 false, $currency_code);
                         }
                     }
-                } else {
-                    if ($special_price && $special_price < $customData[$field][$currency_code]['default']) {
-                        $customData[$field][$currency_code]['default_original_formated'] = $customData[$field][$currency_code]['default_formated'];
+                }
 
-                        $customData[$field][$currency_code]['default'] = $special_price;
-                        $customData[$field][$currency_code]['default_formated'] = $this->formatPrice($special_price,
-                            false, $currency_code);
-                    }
+                if ($special_price && $special_price < $customData[$field][$currency_code]['default']) {
+                    $customData[$field][$currency_code]['default_original_formated'] = $customData[$field][$currency_code]['default_formated'];
+
+                    $customData[$field][$currency_code]['default'] = $special_price;
+                    $customData[$field][$currency_code]['default_formated'] = $this->formatPrice($special_price,
+                        false, $currency_code);
                 }
 
                 if ($type == 'grouped' || $type == 'bundle' || $type == 'configurable') {

--- a/app/design/frontend/base/default/template/algoliasearch/autocomplete/product.phtml
+++ b/app/design/frontend/base/default/template/algoliasearch/autocomplete/product.phtml
@@ -11,7 +11,7 @@ $storeId = Mage::app()->getStore()->getStoreId();
 $currencyCode = Mage::app()->getStore()->getCurrentCurrencyCode();
 
 $priceKey = '.'.$currencyCode.'.default';
-if ($config->isCustomerGroupsEnabled($storeId) && $customerGroupId !== 0) {
+if ($config->isCustomerGroupsEnabled($storeId)) {
     $priceKey = '.'.$currencyCode.'.group_'.$customerGroupId;
 }
 

--- a/app/design/frontend/base/default/template/algoliasearch/instantsearch/hit-item.phtml
+++ b/app/design/frontend/base/default/template/algoliasearch/instantsearch/hit-item.phtml
@@ -11,7 +11,7 @@ $storeId = Mage::app()->getStore()->getStoreId();
 $currencyCode = Mage::app()->getStore()->getCurrentCurrencyCode();
 
 $priceKey = '.'.$currencyCode.'.default';
-if ($config->isCustomerGroupsEnabled($storeId) && $customerGroupId !== 0) {
+if ($config->isCustomerGroupsEnabled($storeId)) {
     $priceKey = '.'.$currencyCode.'.group_'.$customerGroupId;
 }
 


### PR DESCRIPTION
Fix special prices in autocomplete and instantsearch when customer groups are enabled.

Issue was that the defined $priceKey in the templates was considered as "default" when the customer group id is 0.
But in the product helper, the "default" special price was set only in a "else" statement when customer groups are NOT enabled.

Changes : 
- set "group_0" as $priceKey and not "default" when customer groups are enabled.
- index special price for "default" in the product helper in any case.