### PR TITLE
Rename files to fix 404 issue #1095

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue.php
+++ b/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue.php
@@ -1,6 +1,6 @@
 <?php
 
-class Algolia_Algoliasearch_Block_Adminhtml_IndexingQueue extends Mage_Adminhtml_Block_Widget_Grid_Container
+class Algolia_Algoliasearch_Block_Adminhtml_Indexingqueue extends Mage_Adminhtml_Block_Widget_Grid_Container
 {
     /**
      * Initialize Grid Container

--- a/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Edit.php
+++ b/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Edit.php
@@ -1,6 +1,6 @@
 <?php
 
-class Algolia_Algoliasearch_Block_Adminhtml_IndexingQueue_Edit extends Mage_Adminhtml_Block_Widget_Form_Container
+class Algolia_Algoliasearch_Block_Adminhtml_Indexingqueue_Edit extends Mage_Adminhtml_Block_Widget_Form_Container
 {
     /**
      * Internal constructor.

--- a/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Edit/Form.php
+++ b/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Edit/Form.php
@@ -1,6 +1,6 @@
 <?php
 
-class Algolia_Algoliasearch_Block_Adminhtml_IndexingQueue_Edit_Form extends Mage_Adminhtml_Block_Widget_Form
+class Algolia_Algoliasearch_Block_Adminhtml_Indexingqueue_Edit_Form extends Mage_Adminhtml_Block_Widget_Form
 {
     /**
      * @return Algolia_Algoliasearch_Block_Adminhtml_IndexingQueue_Edit_Form

--- a/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Grid.php
+++ b/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Grid.php
@@ -1,6 +1,6 @@
 <?php
 
-class Algolia_Algoliasearch_Block_Adminhtml_IndexingQueue_Grid extends Mage_Adminhtml_Block_Widget_Grid
+class Algolia_Algoliasearch_Block_Adminhtml_Indexingqueue_Grid extends Mage_Adminhtml_Block_Widget_Grid
 {
     /**
      * Initialize Grid Properties

--- a/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Grid/Renderer/Json.php
+++ b/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Grid/Renderer/Json.php
@@ -1,6 +1,6 @@
 <?php
 
-class Algolia_Algoliasearch_Block_Adminhtml_IndexingQueue_Grid_Renderer_Json extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
+class Algolia_Algoliasearch_Block_Adminhtml_Indexingqueue_Grid_Renderer_Json extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract
 {
     /**
      * @param Varien_Object $row

--- a/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Status.php
+++ b/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Status.php
@@ -1,6 +1,6 @@
 <?php
 
-class Algolia_Algoliasearch_Block_Adminhtml_IndexingQueue_Status extends Mage_Adminhtml_Block_Template
+class Algolia_Algoliasearch_Block_Adminhtml_Indexingqueue_Status extends Mage_Adminhtml_Block_Template
 {
     const CRON_QUEUE_FREQUENCY = 330;
 

--- a/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Reindexsku/Edit.php
+++ b/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Reindexsku/Edit.php
@@ -1,6 +1,6 @@
 <?php
 
-class Algolia_Algoliasearch_Block_Adminhtml_ReindexSku_Edit extends Mage_Adminhtml_Block_Widget_Form_Container
+class Algolia_Algoliasearch_Block_Adminhtml_Reindexsku_Edit extends Mage_Adminhtml_Block_Widget_Form_Container
 {
     /**
      * Internal constructor.

--- a/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Reindexsku/Edit/Form.php
+++ b/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Reindexsku/Edit/Form.php
@@ -1,6 +1,6 @@
 <?php
 
-class Algolia_Algoliasearch_Block_Adminhtml_ReindexSku_Edit_Form extends Mage_Adminhtml_Block_Widget_Form
+class Algolia_Algoliasearch_Block_Adminhtml_Reindexsku_Edit_Form extends Mage_Adminhtml_Block_Widget_Form
 {
     /**
      * @return Algolia_AlgoliaSearch_Block_Adminhtml_ReindexSku_Edit_Form

--- a/app/code/community/Algolia/Algoliasearch/controllers/Adminhtml/Algoliasearch/IndexingqueueController.php
+++ b/app/code/community/Algolia/Algoliasearch/controllers/Adminhtml/Algoliasearch/IndexingqueueController.php
@@ -1,6 +1,6 @@
 <?php
 
-class Algolia_Algoliasearch_Adminhtml_Algoliasearch_IndexingQueueController extends Mage_Adminhtml_Controller_Action
+class Algolia_Algoliasearch_Adminhtml_Algoliasearch_IndexingqueueController extends Mage_Adminhtml_Controller_Action
 {
     /**
      * Controller predispatch method

--- a/app/code/community/Algolia/Algoliasearch/controllers/Adminhtml/Algoliasearch/ReindexskuController.php
+++ b/app/code/community/Algolia/Algoliasearch/controllers/Adminhtml/Algoliasearch/ReindexskuController.php
@@ -1,6 +1,6 @@
 <?php
 
-class Algolia_Algoliasearch_Adminhtml_Algoliasearch_ReindexSkuController extends Mage_Adminhtml_Controller_Action
+class Algolia_Algoliasearch_Adminhtml_Algoliasearch_ReindexskuController extends Mage_Adminhtml_Controller_Action
 {
     const MAX_SKUS = 10;
 


### PR DESCRIPTION
The new indexing queue admin page gives a 404 on servers that are case sensitive. These changes rename the files and classes that are affected to fix them.

Fix for issue #1095 