### PR TITLE
pull table name from core/resource to address table prefix schemes wh…

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/IndexChecker.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/IndexChecker.php
@@ -155,7 +155,8 @@ class Algolia_Algoliasearch_Helper_IndexChecker extends Mage_Core_Helper_Abstrac
      * @param $table
      * @return mixed
      */
-    private function checkTablePrefix($table){
+    private function checkTablePrefix($table)
+    {
 
         return Mage::getSingleton('core/resource')->getTableName($table);
 

--- a/app/code/community/Algolia/Algoliasearch/Helper/IndexChecker.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/IndexChecker.php
@@ -157,8 +157,6 @@ class Algolia_Algoliasearch_Helper_IndexChecker extends Mage_Core_Helper_Abstrac
      */
     private function checkTablePrefix($table)
     {
-
         return Mage::getSingleton('core/resource')->getTableName($table);
-
     }
 }


### PR DESCRIPTION
…en processing enterprise partial indexing operations

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Encountered the issue mentioned in the following today
https://github.com/algolia/algoliasearch-magento/issues/1069
I had to write a fix for my client, so I wanted to share so as not to continue to override the module in our local code. 


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->


**Result**

so while I dont have screen shots, but the issues is pretty straight forward. It's not uncommon for a magento store to leverage a prefixed database for security reasons. In this case, the store in question is an enterprise install. It does use the partial indexing that is tracked in the mview_metadata table. When making select calls to confirm indexing status, the select statement will trigger a magento exception since the table view does not exist. The pr resolves this by calling a single instance of the core/resources to pull the tableName that is required. This is accomplished by adding a method that will handle the singleton and it's request. 
The exception stack trace is attached
[alogliaIndexingStackTrace.txt](https://github.com/algolia/algoliasearch-magento/files/2747933/alogliaIndexingStackTrace.txt)







<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->