### PR TITLE
Fix price_with_tax when customerGroups are enabled

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Config.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Config.php
@@ -434,7 +434,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
         return trim(Mage::getStoreConfig(self::INDEX_PREFIX, $storeId));
     }
 
-    public function getAttributesToRetrieve($group_id)
+    public function getAttributesToRetrieve($groupId, $store)
     {
         if (false === $this->isCustomerGroupsEnabled()) {
             return array();
@@ -472,14 +472,24 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
         $currencyDirectory = Mage::getModel('directory/currency');
         $currencies = $currencyDirectory->getConfigAllowCurrencies();
 
-        foreach ($currencies as $currency) {
-            $attributes[] = 'price.'.$currency.'.default';
-            $attributes[] = 'price.'.$currency.'.default_formated';
-            $attributes[] = 'price.'.$currency.'.group_'.$group_id;
-            $attributes[] = 'price.'.$currency.'.group_'.$group_id.'_formated';
-            $attributes[] = 'price.'.$currency.'.group_'.$group_id.'_original_formated';
-            $attributes[] = 'price.'.$currency.'.special_from_date';
-            $attributes[] = 'price.'.$currency.'.special_to_date';
+        /** @var Mage_Tax_Helper_Data $taxHelper */
+        $taxHelper = Mage::helper('tax');
+        $priceFields = ['price'];
+
+        if ($taxHelper->getPriceDisplayType($store) == Mage_Tax_Model_Config::DISPLAY_TYPE_BOTH) {
+            $priceFields[] = 'price_with_tax';
+        }
+
+        foreach ($priceFields as $price) {
+            foreach ($currencies as $currency) {
+                $attributes[] = $price.'.'.$currency.'.default';
+                $attributes[] = $price.'.'.$currency.'.default_formated';
+                $attributes[] = $price.'.'.$currency.'.group_'.$groupId;
+                $attributes[] = $price.'.'.$currency.'.group_'.$groupId.'_formated';
+                $attributes[] = $price.'.'.$currency.'.group_'.$groupId.'_original_formated';
+                $attributes[] = $price.'.'.$currency.'.special_from_date';
+                $attributes[] = $price.'.'.$currency.'.special_to_date';
+            }
         }
 
         $attributes = array_unique($attributes);

--- a/app/code/community/Algolia/Algoliasearch/Helper/Config.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Config.php
@@ -474,7 +474,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
 
         /** @var Mage_Tax_Helper_Data $taxHelper */
         $taxHelper = Mage::helper('tax');
-        $priceFields = ['price'];
+        $priceFields = array('price');
 
         if ($taxHelper->getPriceDisplayType($store) == Mage_Tax_Model_Config::DISPLAY_TYPE_BOTH) {
             $priceFields[] = 'price_with_tax';

--- a/app/design/frontend/base/default/template/algoliasearch/internals/configuration.phtml
+++ b/app/design/frontend/base/default/template/algoliasearch/internals/configuration.phtml
@@ -178,7 +178,7 @@ if ($config->isClickConversionAnalyticsEnabled()) {
  * Generate API keys
  * Docs: https://www.algolia.com/doc/api-client/php/api-keys#generate-key
  */
-$attributesToRetrieve = $config->getAttributesToRetrieve($customerGroupId);
+$attributesToRetrieve = $config->getAttributesToRetrieve($customerGroupId, $store);
 
 if ($attributesToRetrieve) {
     $instantsearchApiKeyParams['attributesToRetrieve'] = $attributesToRetrieve;


### PR DESCRIPTION
When customerGroups are enabled, and magento is configured to display prices both **with** and **without** tax, the prices with tax were not being fetched with the search results.

