### PR TITLE
Fix handle_price when using with&without tax with customer groups

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
@@ -528,20 +528,20 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
         foreach ($fields as $field => $with_tax) {
             $customData[$field] = array();
+            $field_price = (double) $taxHelper->getPrice($product, $product->getPrice(), $with_tax, null, null, null, $product->getStore(), null);
+            $field_special_price = (double) $taxHelper->getPrice($product, $product->getPriceModel()->getFinalPrice(1, $product), $with_tax, null, null, null, $product->getStore(), null);
 
             foreach ($currencies as $currency_code) {
                 $customData[$field][$currency_code] = array();
 
-                $price = (double) $taxHelper->getPrice($product, $product->getPrice(), $with_tax, null, null, null, $product->getStore(), null);
-                $price = $directoryHelper->currencyConvert($price, $baseCurrencyCode, $currency_code);
+                $price = $directoryHelper->currencyConvert($field_price, $baseCurrencyCode, $currency_code);
                 $price += $weeeTaxAmount;
+
+                $special_price = $directoryHelper->currencyConvert($field_special_price, $baseCurrencyCode, $currency_code);
+                $special_price += $weeeTaxAmount;
 
                 $customData[$field][$currency_code]['default'] = $price;
                 $customData[$field][$currency_code]['default_formated'] = $this->formatPrice($price, false, $currency_code);
-
-                $special_price = (double) $taxHelper->getPrice($product, $product->getFinalPrice(), $with_tax, null, null, null, $product->getStore(), null);
-                $special_price = $directoryHelper->currencyConvert($special_price, $baseCurrencyCode, $currency_code);
-                $special_price += $weeeTaxAmount;
 
                 if ($customer_groups_enabled) {
                     // If fetch special price for groups


### PR DESCRIPTION
When using prices with and without taxes, there are
multiple entries in the $fields array. When looping through
the groups $product->getPriceModel()->getFinalPrice() is
called for each group. This sets the data['final_price'] on
the product model each time it is called.

This means that on the second loop of the field array,
when the call to set $special_price uses $product->getFinalPrice()
it is getting value set for the final group in the previous
iteration.

This patch changes the assignment of special_price to recalculate
the final_price everytime, it also moves it out of the currency
loop because the result doesn't depend on the currency.

@JanPetr If this doesn't make sense just shout and I'll try and re-phrase it. Before this patch what happened was we had a special price for the highest numbered customer_group, and we use with and without tax pricing. The loop through without tax is first, so in the without_tax prices were all correct, but the final call to getPriceModel->getFinalPrice is setting the data['final_price'] of the product model to the final_price for the final customer_group. The the with_tax loop starts, and it calculates $special_price using $product->getFinalPrice which returns the one just generated for the customer_group, not the one for the product with a null_group