### PR TITLE
Add max_record_size and indexing queue PID retry method 

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Algoliahelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Algoliahelper.php
@@ -236,7 +236,7 @@ class Algolia_Algoliasearch_Helper_Algoliahelper extends Mage_Core_Helper_Abstra
         $this->lastUsedIndexName = $toIndex;
         $this->lastTaskId = $res['taskID'];
     }
-    
+
     /**
      * @param $fromIndexName
      * @param $toIndexName

--- a/app/code/community/Algolia/Algoliasearch/Helper/Algoliahelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Algoliahelper.php
@@ -13,7 +13,7 @@ class Algolia_Algoliasearch_Helper_Algoliahelper extends Mage_Core_Helper_Abstra
     protected $config;
 
     /** @var int */
-    protected $maxRecordSize = 20000;
+    protected $maxRecordSize;
 
     /** @var array */
     protected $potentiallyLongAttributes = array('description', 'short_description', 'meta_description', 'content');
@@ -332,11 +332,21 @@ class Algolia_Algoliasearch_Helper_Algoliahelper extends Mage_Core_Helper_Abstra
         }
     }
 
+    private function getMaxRecordSize()
+    {
+        if (!$this->maxRecordSize) {
+            $this->maxRecordSize = $this->config->getMaxRecordSizeLimit()
+                ? $this->config->getMaxRecordSizeLimit() : $this->config->getDefaultMaxRecordSize();
+        }
+
+        return $this->maxRecordSize;
+    }
+
     public function handleTooBigRecord($object)
     {
         $size = mb_strlen(json_encode($object));
 
-        if ($size > $this->maxRecordSize) {
+        if ($size > $this->getMaxRecordSize()) {
             foreach ($this->potentiallyLongAttributes as $attribute) {
                 if (isset($object[$attribute])) {
                     unset($object[$attribute]);
@@ -345,7 +355,7 @@ class Algolia_Algoliasearch_Helper_Algoliahelper extends Mage_Core_Helper_Abstra
 
             $size = mb_strlen(json_encode($object));
 
-            if ($size > $this->maxRecordSize) {
+            if ($size > $this->getMaxRecordSize()) {
                 $object = false;
             }
         }

--- a/app/code/community/Algolia/Algoliasearch/Helper/Config.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Config.php
@@ -88,6 +88,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     const PREVENT_BACKEND_RENDERING_DISPLAY_MODE = 'algoliasearch/advanced/prevent_backend_rendering_display_mode';
     const BACKEND_RENDERING_ALLOWED_USER_AGENTS = 'algoliasearch/advanced/backend_rendering_allowed_user_agents';
     const NON_CASTABLE_ATTRIBUTES = 'algoliasearch/advanced/non_castable_attributes';
+    const MAX_RECORD_SIZE_LIMIT = 'algoliasearch/advanced/max_record_size_limit';
 
     const SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
     const LOGGING_ENABLED = 'algoliasearch/credentials/debug';
@@ -97,6 +98,8 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
     const EXTRA_SETTINGS_PAGES = 'algoliasearch/advanced_settings/pages_extra_settings';
     const EXTRA_SETTINGS_SUGGESTIONS = 'algoliasearch/advanced_settings/suggestions_extra_settings';
     const EXTRA_SETTINGS_ADDITIONAL_SECTIONS = 'algoliasearch/advanced_settings/additional_sections_extra_settings';
+
+    const DEFAULT_MAX_RECORD_SIZE = 10000;
 
     protected $_productTypeMap = array();
 
@@ -741,6 +744,16 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
         }
 
         return $nonCastableAttributes;
+    }
+
+    public function getDefaultMaxRecordSize()
+    {
+        return self::DEFAULT_MAX_RECORD_SIZE;
+    }
+
+    public function getMaxRecordSizeLimit($storeId = null)
+    {
+        return Mage::getStoreConfig(self::MAX_RECORD_SIZE_LIMIT, $storeId);
     }
 
     private function getCustomRanking($configName, $storeId = null)

--- a/app/code/community/Algolia/Algoliasearch/Model/Queue.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Queue.php
@@ -5,6 +5,8 @@ class Algolia_Algoliasearch_Model_Queue
     const SUCCESS_LOG = 'algoliasearch_queue_log.txt';
     const ERROR_LOG = 'algoliasearch_queue_errors.log';
 
+    const UNLOCK_STACKED_JOBS_AFTER_MINUTES = 15;
+
     protected $table;
     protected $logTable;
     protected $archiveTable;
@@ -92,6 +94,7 @@ class Algolia_Algoliasearch_Model_Queue
         }
 
         $this->clearOldLogRecords();
+        $this->unlockStackedJobs();
 
         $this->logRecord = array(
             'started' => date('Y-m-d H:i:s'),
@@ -136,7 +139,7 @@ class Algolia_Algoliasearch_Model_Queue
             // and therefore are not indexed yet in TMP index
             if ($job['method'] === 'moveProductsTmpIndex' && $this->noOfFailedJobs > 0) {
                 // Set pid to NULL so it's not deleted after
-                $this->db->query("UPDATE {$this->db->quoteIdentifier($this->table, true)} SET pid = NULL WHERE job_id = ".$job['job_id']);
+                $this->db->query("UPDATE {$this->db->quoteIdentifier($this->table, true)} SET pid = NULL, locked_at = NULL WHERE job_id = ".$job['job_id']);
 
                 continue;
             }
@@ -168,7 +171,7 @@ class Algolia_Algoliasearch_Model_Queue
 
                 // Increment retries, set the job ID back to NULL
                 $updateQuery = "UPDATE {$this->db->quoteIdentifier($this->table, true)} 
-                  SET pid = NULL, retries = retries + 1 , error_log = '" . addslashes($logMessage) . "'
+                  SET pid = NULL, locked_at = NULL, retries = retries + 1 , error_log = '" . addslashes($logMessage) . "'
                   WHERE job_id IN (".implode(', ', (array) $job['merged_ids']).")";
                 $this->db->query($updateQuery);
             }
@@ -267,8 +270,8 @@ class Algolia_Algoliasearch_Model_Queue
 
                 // Reserve all new jobs since last run
                 $this->db->query("UPDATE {$this->db->quoteIdentifier($this->table, true)} 
-                  SET pid = " . $pid . ' 
-                  WHERE job_id >= ' . $firstJobId . " AND job_id <= $lastJobId");
+                  SET pid = " . $pid . ", locked_at = '" . date('Y-m-d H:i:s') . "' 
+                  WHERE job_id >= " . $firstJobId . " AND job_id <= " . $lastJobId);
             }
 
             $this->db->commit();
@@ -470,5 +473,13 @@ class Algolia_Algoliasearch_Model_Queue
             $this->db->truncateTable($this->table);
             $this->logger->log("{$this->table} table has been truncated.");
         }
+    }
+
+    private function unlockStackedJobs()
+    {
+        $this->db->update($this->table, array(
+            'locked_at' => null,
+            'pid' => null,
+        ), 'locked_at < (NOW() - INTERVAL ' . self::UNLOCK_STACKED_JOBS_AFTER_MINUTES . ' MINUTE)');
     }
 }

--- a/app/code/community/Algolia/Algoliasearch/Model/Source/MaxRecordSize.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Source/MaxRecordSize.php
@@ -6,7 +6,6 @@ class Algolia_Algoliasearch_Model_Source_MaxRecordSize
 
     public function toOptionArray()
     {
-
         if (!$this->_options) {
             $options[] = Algolia_Algoliasearch_Helper_Config::DEFAULT_MAX_RECORD_SIZE;
             $proxyHelper = Mage::helper('algoliasearch/proxyHelper');
@@ -30,6 +29,7 @@ class Algolia_Algoliasearch_Model_Source_MaxRecordSize
 
             $this->_options = $formattedOptions;
         }
+
         return $this->_options;
     }
 }

--- a/app/code/community/Algolia/Algoliasearch/Model/Source/MaxRecordSize.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Source/MaxRecordSize.php
@@ -20,12 +20,12 @@ class Algolia_Algoliasearch_Model_Source_MaxRecordSize
 
             rsort($options);
 
-            $formattedOptions = [];
+            $formattedOptions = array();
             foreach ($options as $option) {
-                $formattedOptions[] = [
+                $formattedOptions[] = array(
                     'value' => $option,
                     'label' => $option,
-                ];
+                );
             }
 
             $this->_options = $formattedOptions;

--- a/app/code/community/Algolia/Algoliasearch/Model/Source/MaxRecordSize.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Source/MaxRecordSize.php
@@ -1,0 +1,35 @@
+<?php
+
+class Algolia_Algoliasearch_Model_Source_MaxRecordSize
+{
+    protected $_options;
+
+    public function toOptionArray()
+    {
+
+        if (!$this->_options) {
+            $options[] = Algolia_Algoliasearch_Helper_Config::DEFAULT_MAX_RECORD_SIZE;
+            $proxyHelper = Mage::helper('algoliasearch/proxyHelper');
+            $clientData = $proxyHelper->getClientConfigurationData();
+
+            if ($clientData && isset($clientData['max_record_size'])) {
+                if (!in_array($clientData['max_record_size'], $options)) {
+                    $options[] = $clientData['max_record_size'];
+                }
+            }
+
+            rsort($options);
+
+            $formattedOptions = [];
+            foreach ($options as $option) {
+                $formattedOptions[] = [
+                    'value' => $option,
+                    'label' => $option,
+                ];
+            }
+
+            $this->_options = $formattedOptions;
+        }
+        return $this->_options;
+    }
+}

--- a/app/code/community/Algolia/Algoliasearch/etc/system.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/system.xml
@@ -1327,20 +1327,6 @@
                                 ]]>
                             </comment>
                         </non_castable_attributes>
-                        <max_record_size_limit translate="label comment">
-                            <label>Max Record Size Limit</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>algoliasearch/source_maxRecordSize</source_model>
-                            <sort_order>130</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <comment>
-                                <![CDATA[
-                                    You can set the max record size limit in bytes here. If you are receiving "Record is too big" errors during indexing, try increasing your limit if it is available for your plan. To learn more, please read <a href="https://www.algolia.com/doc/faq/basics/is-there-a-size-limit-for-my-index-records/" target="_blank">this documentation</a>.
-                                ]]>
-                            </comment>
-                        </max_record_size_limit>
                     </fields>
                 </advanced>
                 <advanced_settings translate="label">

--- a/app/code/community/Algolia/Algoliasearch/etc/system.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/system.xml
@@ -1327,6 +1327,20 @@
                                 ]]>
                             </comment>
                         </non_castable_attributes>
+                        <max_record_size_limit translate="label comment">
+                            <label>Max Record Size Limit</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>algoliasearch/source_maxRecordSize</source_model>
+                            <sort_order>130</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment>
+                                <![CDATA[
+                                    You can set the max record size limit in bytes here. If you are receiving "Record is too big" errors during indexing, try increasing your limit if it is available for your plan. To learn more, please read <a href="https://www.algolia.com/doc/faq/basics/is-there-a-size-limit-for-my-index-records/" target="_blank">this documentation</a>.
+                                ]]>
+                            </comment>
+                        </max_record_size_limit>
                     </fields>
                 </advanced>
                 <advanced_settings translate="label">

--- a/app/code/community/Algolia/Algoliasearch/sql/algoliasearch_setup/mysql4-upgrade-1.15.0-1.16.0.php
+++ b/app/code/community/Algolia/Algoliasearch/sql/algoliasearch_setup/mysql4-upgrade-1.15.0-1.16.0.php
@@ -1,0 +1,15 @@
+<?php
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+$tableName = $installer->getTable('algoliasearch/queue');
+
+$installer->getConnection()->addColumn($tableName, 'locked_at', array(
+    'type' => Varien_Db_Ddl_Table::TYPE_DATETIME,
+    'after' => 'job_id',
+    'nullable' => true,
+    'comment' => 'Time of job creation',
+));
+
+$installer->endSetup();


### PR DESCRIPTION
**Summary**
Reduce the number of "Record size is too big" errors by adjusting the record size according to plan through system admin and default the size to 10000. Update the retry method for stuck jobs with PIDs that have not be unassigned during system error (ie time out or max memory limits). 


**Result**
* Added max_record_size to pull limit from plan in system configuration 
* Changed the default max_record_size to 10000
* Added locked_at column to queue table and unlockStackedJobs() method to Queue model for jobs processing stuck after system error