### PR TITLE
Fix sticky autocomplete input value after clear by toggle

### DIFF
--- a/js/algoliasearch/internals/frontend/common.js
+++ b/js/algoliasearch/internals/frontend/common.js
@@ -494,6 +494,10 @@ document.addEventListener("DOMContentLoaded", function (e) {
 			var input = $(this).closest('#algolia-searchbox').find('input');
 			input.val('');
 
+			if (input.data('aaAutocomplete')) {
+				input.data('aaAutocomplete').input.query = '';
+			}
+
 			if (algoliaConfig.autocomplete.enabled != algoliaConfig.instant.enabled) {
 				input.get(0).dispatchEvent(new Event('input'));
 			}


### PR DESCRIPTION
**Summary**
Helpscout issue (133308) on sticky autocomplete input value after clearing via toggle. 

**Result**
Added to the clear event to clear the autocomplete input data for query to clear value.  