### PR TITLE
Bump to 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Update max PHP dependency (#1090)
 - Update Reindex SKU for improved messaging  (#1098)
 - Added ProxyHelper to assist with plan upsell (#1109)
-- Update all algoliaBundle.js (#1121)
+- Update autocomplete version in algoliaBundle.js (#1121)
 - Improvements to Indexing and Indexing Queue
 	- Skip inactive stores (#1101)
 	- Add distinct to category collection fetch (#1104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # CHANGE LOG
 
+## 1.16.0
+
+### Updates
+- Update max PHP dependency (#1090)
+- Update Reindex SKU for improved messaging  (#1098)
+- Added ProxyHelper to assist with plan upsell (#1109)
+- Update all algoliaBundle.js (#1121)
+- Improvements to Indexing and Indexing Queue
+	- Skip inactive stores (#1101)
+	- Add distinct to category collection fetch (#1104)
+	- Fail "Remove Algolia products" silently on non-existent index (#1111)
+	- Fetch max_record_size and add retry on stuck PIDs for indexing queue (#1117)
+
+### Fixes
+- Fix directory casing 404s (#1095)
+- Add table prefixes when calling core/resource instances (#1097)
+- Fix price_with_tax for customer groups (#1100)
+- Fix autocomplete frontend hook (#1102)
+- Fix jobs locking (#1118)
+- Fix Dockerfile (#1120)
+- Fix sticky autocomplete input value after clear toggle (#1122)
+
 ## 1.15.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Algolia Search for Magento 1.6+
 ==================
 
-![Latest version](https://img.shields.io/badge/latest-1.15.0-green.svg)
+![Latest version](https://img.shields.io/badge/latest-1.16.0-green.svg)
 
 [![Build Status](https://travis-ci.org/algolia/algoliasearch-magento.svg?branch=master)](https://travis-ci.org/algolia/algoliasearch-magento)
 ![PHP >= 5.3](https://img.shields.io/badge/php-%3E=5.3-green.svg)

--- a/app/code/community/Algolia/Algoliasearch/etc/system.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/system.xml
@@ -4,7 +4,7 @@
         <algoliasearch translate="label" module="algoliasearch">
             <label>
                 <![CDATA[
-                Algolia Search 1.15.0
+                Algolia Search 1.16.0
                 <style>
                     .algoliasearch-admin-menu span {
                         padding-left: 38px !important;

--- a/app/etc/modules/Algolia_Algoliasearch.xml
+++ b/app/etc/modules/Algolia_Algoliasearch.xml
@@ -4,7 +4,7 @@
         <Algolia_Algoliasearch>
             <active>true</active>
             <codePool>community</codePool>
-            <version>1.15.0</version>
+            <version>1.16.0</version>
         </Algolia_Algoliasearch>
     </modules>
 </config>


### PR DESCRIPTION
## 1.16.0

### Updates
- Update max PHP dependency (#1090)
- Update Reindex SKU for improved messaging  (#1098)
- Added ProxyHelper to assist with plan upsell (#1109)
- Update autocomplete version in algoliaBundle.js (#1121)
- Improvements to Indexing and Indexing Queue
	- Skip inactive stores (#1101)
	- Add distinct to category collection fetch (#1104)
	- Fail "Remove Algolia products" silently on non-existent index (#1111)
	- Fetch max_record_size and add retry on stuck PIDs for indexing queue (#1117)

### Fixes
- Fix directory casing 404s (#1095)
- Add table prefixes when calling core/resource instances (#1097)
- Fix price_with_tax for customer groups (#1100)
- Fix autocomplete frontend hook (#1102)
- Fix jobs locking (#1118)
- Fix Dockerfile (#1120)
- Fix sticky autocomplete input value after clear toggle (#1122)