### PR TITLE
Add available on store view currencies to the price facet.

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Entity/Producthelper.php
@@ -236,9 +236,7 @@ class Algolia_Algoliasearch_Helper_Entity_Producthelper extends Algolia_Algolias
 
         $facets = $this->config->getFacets($storeId);
 
-        /** @var Mage_Directory_Model_Currency $directoryCurrency */
-        $directoryCurrency = Mage::getModel('directory/currency');
-        $currencies = $directoryCurrency->getConfigAllowCurrencies();
+        $currencies = Mage::app()->getStore($storeId)->getAvailableCurrencyCodes();
 
         foreach ($facets as $facet) {
             if ($facet['attribute'] === 'price') {


### PR DESCRIPTION
**Summary**

Currently, currencies are collected from all store/website/default views and the same list of them is pushed to Algolia to facets of all indexes. For example, the US store view has USD currency and Germany EUR, in this case, price facets will contain both USD and EUR prices.

**Result**

The PR adds the ability to index price facets with the currencies allowed on the specific website/store view.