### PR TITLE
Fix #1135 - Fix missing options on additional section index

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Data.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Data.php
@@ -165,6 +165,8 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
 
         $additionnal_sections = $this->config->getAutocompleteSections();
 
+        $emulationInfo = $this->startEmulation($storeId);
+
         foreach ($additionnal_sections as $section) {
             if ($section['name'] === 'products' || $section['name'] === 'categories' || $section['name'] === 'pages' || $section['name'] === 'suggestions') {
                 continue;
@@ -183,6 +185,8 @@ class Algolia_Algoliasearch_Helper_Data extends Mage_Core_Helper_Abstract
             $this->algolia_helper->setSettings($index_name,
                 $this->additionalsections_helper->getIndexSettings($storeId));
         }
+
+        $this->stopEmulation($emulationInfo);
     }
 
     public function rebuildStorePageIndex($storeId, $pageIds = null)

--- a/app/code/community/Algolia/Algoliasearch/Model/Indexer/Algoliacategories.php
+++ b/app/code/community/Algolia/Algoliasearch/Model/Indexer/Algoliacategories.php
@@ -78,7 +78,9 @@ class Algolia_Algoliasearch_Model_Indexer_Algoliacategories extends Algolia_Algo
                     $productIds = $category->getAffectedProductIds();
                 }
 
-                if (!$category->getData('is_active')) {
+                $isActive = $category->getResource()
+                    ->getAttributeRawValue($category->getId(), "is_active", $category->getStoreId());
+                if ((int) $isActive !== 1) {
                     $categories = array_merge(array($category->getId()), $category->getAllChildren(true));
                     $event->addNewData('catalogsearch_delete_category_id', $categories);
 


### PR DESCRIPTION
Fix 1:  #1135
Fix 2: adding custom section (es. manufacturer) missing attribute options into algolia's section index.
This issue happen when status for product is disabled on store 0 but enabled for a custom store.