### PR TITLE
Configuration fix Google Analytics dependent fields

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/etc/system.xml
+++ b/app/code/community/Algolia/Algoliasearch/etc/system.xml
@@ -1015,7 +1015,7 @@
                                     <p>Default value: 3000</p>
                                 ]]>
                             </comment>
-                            <depends><enable_analytics>1</enable_analytics></depends>
+                            <depends><enable>1</enable></depends>
                         </delay>
                         <trigger_on_ui_interaction translate="label comment">
                             <label>Trigger the push function before the the delay on UI interaction</label>
@@ -1031,7 +1031,7 @@
                                     <p>Default value: Yes</p>
                                 ]]>
                             </comment>
-                            <depends><enable_analytics>1</enable_analytics></depends>
+                            <depends><enable>1</enable></depends>
                         </trigger_on_ui_interaction>
                         <push_initial_search translate="label comment">
                             <label>Trigger the push function after the initial search</label>
@@ -1047,7 +1047,7 @@
                                     <p>Default value: No</p>
                                 ]]>
                             </comment>
-                            <depends><enable_analytics>1</enable_analytics></depends>
+                            <depends><enable>1</enable></depends>
                         </push_initial_search>
                     </fields>
                 </analytics>


### PR DESCRIPTION
**Summary**
In System > Configuration > Algolia Search > Google Analytics, when you enable the configuration, it does not display the dependant fields to configure the settings. 

HS Ticket: #201666

**Result**
Updated the depends node to the correct field name that was changed when we introduced Click Analytics. 