### PR TITLE
Fix renamed class reference - Algolia Search - Indexing Queue

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Grid.php
+++ b/app/code/community/Algolia/Algoliasearch/Block/Adminhtml/Indexingqueue/Grid.php
@@ -65,7 +65,7 @@ class Algolia_Algoliasearch_Block_Adminhtml_Indexingqueue_Grid extends Mage_Admi
         $this->addColumn('data', array(
             'header' => Mage::helper('algoliasearch')->__('Data'),
             'index' => 'data',
-            'renderer' => 'Algolia_Algoliasearch_Block_Adminhtml_IndexingQueue_Grid_Renderer_Json'
+            'renderer' => 'Algolia_Algoliasearch_Block_Adminhtml_Indexingqueue_Grid_Renderer_Json'
         ));
 
         $this->addColumn('max_retries', array(


### PR DESCRIPTION
Fixes a problem described in the latter comments of #1095.
When visiting Admin `Algolia Search - Indexing Queue` the page is blank/white/empty.
If errors are enabled the error is `Fatal error: Uncaught Error: Call to a member function setColumn() on boolean in app/code/core/Mage/Adminhtml/Block/Widget/Grid/Column.php on line 291`

This is due to the class reference being incorrectly capitalised.