### PR TITLE
fix: Insights URL for CC Analytics only

### DIFF
--- a/app/design/frontend/base/default/template/algoliasearch/internals/configuration.phtml
+++ b/app/design/frontend/base/default/template/algoliasearch/internals/configuration.phtml
@@ -263,6 +263,7 @@ $algoliaJsConfig = array(
     'maxValuesPerFacet' => (int) $config->getMaxValuesPerFacet(),
     'autofocus' => true,
     'ccAnalytics' => array(
+        'enabled' => $config->isClickConversionAnalyticsEnabled(),
         'ISSelector' => $config->getClickConversionAnalyticsISSelector(),
         'conversionAnalyticsMode' => $config->getConversionAnalyticsMode(),
         'addToCartSelector' => $config->getConversionAnalyticsAddToCartSelector(),

--- a/js/algoliasearch/click_conversion_analytics.js
+++ b/js/algoliasearch/click_conversion_analytics.js
@@ -79,11 +79,6 @@ algolia.registerHook('beforeInstantsearchStart', function (search) {
 	return search;
 });
 
-algolia.registerHook('beforeWidgetInitialization', function (allWidgetConfiguration) {
-	allWidgetConfiguration['hits']
-	return allWidgetConfiguration;
-});
-
 algolia.registerHook('beforeInstantsearchInit', function (instantsearchOptions) {
 	instantsearchOptions.searchParameters['clickAnalytics'] = true;
 	return instantsearchOptions;

--- a/js/algoliasearch/instantsearch.js
+++ b/js/algoliasearch/instantsearch.js
@@ -2,6 +2,10 @@ document.addEventListener("DOMContentLoaded", function (event) {
 	algoliaBundle.$(function ($) {
 
 		function makeUrlForInsights(baseUrl, objectID, queryID, indexName) {
+			if (algoliaConfig.ccAnalytics.enabled !== true) {
+				return baseUrl;
+			}
+
 			var _baseUrl = baseUrl.indexOf('?') === -1 ? baseUrl + '?' : baseUrl;
 			return _baseUrl + $.param({
 				queryID: queryID,


### PR DESCRIPTION
**Summary**
Insights URL was not optional and includes the URL even if cc analytics was not enabled.



**Result**
Removed unused event. Added `enabled` as a ccAnalytics parameter and added condition to the makeURL function. 