### PR TITLE
Fix popular queries empty result condition

### DIFF
--- a/app/code/community/Algolia/Algoliasearch/Helper/Config.php
+++ b/app/code/community/Algolia/Algoliasearch/Helper/Config.php
@@ -571,7 +571,7 @@ class Algolia_Algoliasearch_Helper_Config extends Mage_Core_Helper_Abstract
 
     public function getPopularQueries($storeId = null)
     {
-        if (!$this->isInstantEnabled($storeId) || !$this->showSuggestionsOnNoResultsPage($storeId)) {
+        if (!$this->showSuggestionsOnNoResultsPage($storeId)) {
             return array();
         }
 


### PR DESCRIPTION
Empty result popular queries feature is in both autocomplete and in instantsearch. If instantsearch is not enabled, the method will return an empty array. 

Remove condition in \Algolia_Algoliasearch_Helper_Config::getPopularQueries() to remove instantsearch dependency. 

