### PR TITLE
Security: due to supply chain attack, pollyfill JS removed

### DIFF
--- a/app/design/frontend/base/default/layout/algoliasearch.xml
+++ b/app/design/frontend/base/default/layout/algoliasearch.xml
@@ -9,19 +9,6 @@
             <action method="addJs"><script>algoliasearch/internals/frontend/Function.prototype.bind.js</script></action>
             <action method="addJs"><script>algoliasearch/internals/frontend/algoliaBundle.min.js</script></action>
             <action method="addJs"><script>algoliasearch/internals/frontend/common.js</script></action>
-
-            <block type="core/text" name="algolia-polyfill">
-                <action method="setText">
-                    <text>
-                        <![CDATA[
-                            <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-                            <!--[if lte IE 9]>
-                                <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
-                            <![endif]-->
-                        ]]>
-                    </text>
-                </action>
-            </block>
         </reference>
 
         <reference name="content">


### PR DESCRIPTION
cf https://sansec.io/research/polyfill-supply-chain-attack

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

As explain in the https://sansec.io/research/polyfill-supply-chain-attack, the Polyfill JS contains a malicious script.
And, like IE 9 and below, are very rarely used now: 

![image](https://github.com/algolia/algoliasearch-magento/assets/465524/8b63f820-41f8-4314-becf-5a04e9600566)
Source: https://www.w3counter.com/trends

I suggest deleting the polyfill addition in layout

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->